### PR TITLE
e2-e3: fix `can't render static file`

### DIFF
--- a/docs/e-forecast-data/e2-e3-numerical-weather-forecasting-model.mdx
+++ b/docs/e-forecast-data/e2-e3-numerical-weather-forecasting-model.mdx
@@ -4,11 +4,14 @@ sidebar_position: 2
 
 # Numerical weather forecasting model ICON-CH1/2-EPS
 
+import BrowserOnly from '@docusaurus/BrowserOnly';
 import ForecastDomainMap from './interactive-map/ForecastDomainMap';
 
 MeteoSwiss uses two models, [**ICON-CH1-EPS** and **ICON-CH2-EPS**](https://www.meteoswiss.admin.ch/weather/warning-and-forecasting-systems/icon-forecasting-systems.html), to forecast the atmospheric state in Switzerland and its surroundings over a longer period than [nowcasting](/e-forecast-data/e1-short-term-forecast-data), providing predictions for up to five days. Both models include [ensemble data assimilation](https://www.meteoswiss.admin.ch/weather/warning-and-forecasting-systems/icon-forecasting-systems/ensemble-data-assimilation.html), where multiple simulations with slightly perturbed initial conditions help account for forecast uncertainty. Forecasts can include the full ensemble or just the unperturbed control run.
 
-<ForecastDomainMap />
+<BrowserOnly fallback={<div>Loading map...</div>}>
+  {() => <ForecastDomainMap />}
+</BrowserOnly>
 
 <br></br>
 


### PR DESCRIPTION
- Change output format of ` e2-e3-numerical-weather-forecasting-model` to `.mdx` (needed to work with syntax `<ForecastDomainMap />`)
- Add `BrowserOnly` to ensure the map component is only rendered on the client side, and not during static build time