### PR TITLE
Sidebar/title translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,23 @@ They are provided as ‘Assets’ to the corresponding dataset/‘Collection‘ 
 
 <br>
 -->
+
+## Development
+
+Run the app locally / in the devcontainer:
+
+```
+yarn run start
+```
+
+Run a specific locale:
+
+```
+yarn run start --locale fr
+```
+
+And to export all translatable strings for a locale:
+
+```
+yarn write-translations --locale fr
+```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ They are provided as ‘Assets’ to the corresponding dataset/‘Collection‘ 
 
 ## Development
 
-Run the app locally / in the devcontainer:
+Run the app locally:
 
 ```
 yarn run start

--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -1,14 +1,33 @@
 {
   "Data Documentation": {
-    "message": "📖 Daten Dokumentation anschauen"
+    "message": "Data Dokumentation"
   },
-  "Open Data Documentation": {
+  "Open Data documentation": {
     "message": "Open Data Dokumentation",
     "description": "Homepage title"
   },
-  "MeteoSwiss - Open Data Documentation": {
+  "MeteoSwiss - Open Data documentation": {
     "message": "MeteoSwiss - Open Data Dokumentation",
     "description": "Homepage description"
+  },
+  "homepage.main_title": {
+    "message": "Documentation under construction",
+    "description": "Title on the main page"
+  },
+  "homepage.main_text": {
+    "message": "The documentations of the Open Data products linked below explain what the data represents, its models, abstractions and terminology.",
+    "description": "The main explanation text on the homepage"
+  },
+  "Status": {
+    "message": "Status"
+  },
+  "homepage.status_text": {
+    "message": "We are currently setting up our service as ALPHA. Everything is subject to change without prior notice.",
+    "description": "The status text on the homepage"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Navigation der letzten Beiträge im Blog",
+    "description": "The ARIA label for recent posts in the blog sidebar"
   },
   "theme.ErrorPageContent.title": {
     "message": "Die Seite ist abgestürzt.",
@@ -173,10 +192,6 @@
     "message": "Schließen",
     "description": "The ARIA label for close button of announcement bar"
   },
-  "theme.blog.sidebar.navAriaLabel": {
-    "message": "Navigation der letzten Beiträge im Blog",
-    "description": "The ARIA label for recent posts in the blog sidebar"
-  },
   "theme.CodeBlock.copied": {
     "message": "Kopiert",
     "description": "The copied button label on code blocks"
@@ -320,28 +335,5 @@
   "theme.tags.tagsPageTitle": {
     "message": "Tags",
     "description": "The title of the tag list page"
-  },
-  "homepage.main_text": {
-    "message": "Die unten verlinkten Dokumentationen der Open-Data-Produkte erklären, was die Daten darstellen, ihre Modelle, Abstraktionen und Terminologie.",
-    "description": "The main explanation text on the homepage"
-  },
-  "Status": {
-    "message": "Status"
-  },
-  "homepage.status_text": {
-    "message": "Wir richten unseren Dienst derzeit als ALPHA ein. Alles kann sich ohne vorherige Ankündigung ändern.",
-    "description": "The status text on the homepage"
-  },
-  "homepage.main_title": {
-    "message": "Dokumentation im Aufbau",
-    "description": "Title on the main page"
-  },
-  "Open Data documentation": {
-    "message": "Open Data Dokumentation",
-    "description": "Homepage title"
-  },
-  "MeteoSwiss - Open Data documentation": {
-    "message": "MeteoSchweiz - Open Data Dokumentation",
-    "description": "Homepage description"
   }
 }

--- a/i18n/de/docusaurus-plugin-content-docs/current.json
+++ b/i18n/de/docusaurus-plugin-content-docs/current.json
@@ -11,14 +11,6 @@
     "message": "B - Atmosphärenmessdaten",
     "description": "The label for category B - Atmosphere measurements in sidebar dataSidebar"
   },
-  "sidebar.dataSidebar.category.Open Data Documentation": {
-    "message": "Open Data Documentation",
-    "description": "The label for category Open Data Documentation in sidebar dataSidebar"
-  },
-  "sidebar.dataSidebar.category.General information": {
-    "message": "Allgemeine Informationen",
-    "description": "The label for category General information in sidebar dataSidebar"
-  },
   "sidebar.dataSidebar.category.C - Climate data": {
     "message": "C - Klimadaten",
     "description": "The label for category C - Climate data in sidebar dataSidebar"

--- a/i18n/de/docusaurus-plugin-content-docs/current/a-data-groundbased/a1-automatic-weather-stations.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/a-data-groundbased/a1-automatic-weather-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+title: Automatische Wetterstationen
 ---
 
 # Automatische Wetterstationen

--- a/i18n/de/docusaurus-plugin-content-docs/current/a-data-groundbased/a2-automatic-precipitation-stations.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/a-data-groundbased/a2-automatic-precipitation-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+title: Automatische Niederschlagsstationen
 ---
 
 # Automatische Niederschlagsstationen

--- a/i18n/de/docusaurus-plugin-content-docs/current/a-data-groundbased/a3-automatic-tower-stations.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/a-data-groundbased/a3-automatic-tower-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: Automatische Turmstationen
 ---
 
 # Automatische Turmstationen

--- a/i18n/de/docusaurus-plugin-content-docs/current/a-data-groundbased/a4-automatic-soil-stations.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/a-data-groundbased/a4-automatic-soil-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+title: Automatische Bodenfeuchtestationen
 ---
 
 # Automatische Bodenfeuchtestationen

--- a/i18n/de/docusaurus-plugin-content-docs/current/a-data-groundbased/a5-manual-precipitation-stations.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/a-data-groundbased/a5-manual-precipitation-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+title: Manuelle Niederschlagsstationen
 ---
 
 # Manuelle Niederschlagsstationen

--- a/i18n/de/docusaurus-plugin-content-docs/current/a-data-groundbased/a6-totaliser-precipitation-stations.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/a-data-groundbased/a6-totaliser-precipitation-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+title: Totalisator-Niederschlagsstationen
 ---
 
 # Totalisator-Niederschlagsstationen

--- a/i18n/de/docusaurus-plugin-content-docs/current/a-data-groundbased/a7-pollen-stations.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/a-data-groundbased/a7-pollen-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 7
+title: Pollenstationen
 ---
 
 # Pollenstationen

--- a/i18n/de/docusaurus-plugin-content-docs/current/a-data-groundbased/a8-meteorological-visual-observations.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/a-data-groundbased/a8-meteorological-visual-observations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 8
+title: Meteorologische Augenbeobachtungen
 ---
 
 # Meteorologische Augenbeobachtungen

--- a/i18n/de/docusaurus-plugin-content-docs/current/a-data-groundbased/a9-phenological-observations.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/a-data-groundbased/a9-phenological-observations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 9
+title: Phänologische Beobachtungen
 ---
 
 # Phänologische Beobachtungen

--- a/i18n/de/docusaurus-plugin-content-docs/current/b-data-atmosphere/b1-radio-sounding.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/b-data-atmosphere/b1-radio-sounding.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+title: Radiosondierungen
 ---
 
 # Radiosondierungen

--- a/i18n/de/docusaurus-plugin-content-docs/current/b-data-atmosphere/b2-ralmo.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/b-data-atmosphere/b2-ralmo.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+title: Raman-LIDAR for Meteorological Observation (RALMO)
 ---
 <!-- @NOSPELL@ -->
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/b-data-atmosphere/b3-lidar-ceilometer-chm15k.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/b-data-atmosphere/b3-lidar-ceilometer-chm15k.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: LIDAR Ceilometer CHM15K
 ---
 <!-- @NOSPELL@ -->
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/b-data-atmosphere/b4-ozone-measurements-total-column.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/b-data-atmosphere/b4-ozone-measurements-total-column.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: Ozone measurements – Total column (Dobson, Brewer)
 ---
 <!-- @NOSPELL@ -->
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/b-data-atmosphere/b5-ozone-measurements-profiles.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/b-data-atmosphere/b5-ozone-measurements-profiles.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: Ozone measurements – Profiles (O3 radio soundings, SOMORA)
 ---
 <!-- @NOSPELL@ -->
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/b-data-atmosphere/b6-sacram.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/b-data-atmosphere/b6-sacram.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: Swiss Alpine Climate Radiation Monitoring (SACRaM)
 ---
 <!-- @NOSPELL@ -->
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/c-climate-data/c1-climate-stations_homogeneous.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/c-climate-data/c1-climate-stations_homogeneous.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+title: Klimastationen – Homogene Messreihen
 ---
 
 # Klimastationen – Homogene Messreihen

--- a/i18n/de/docusaurus-plugin-content-docs/current/c-climate-data/c2-climate-percipitation-stations_homogeneous.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/c-climate-data/c2-climate-percipitation-stations_homogeneous.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+title: Niederschlags-Klimastationen – Homogene Messreihen
 ---
 
 # Niederschlags-Klimastationen – Homogene Messreihen

--- a/i18n/de/docusaurus-plugin-content-docs/current/c-climate-data/c3-ground-based-climate-data.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/c-climate-data/c3-ground-based-climate-data.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: Bodengestützte räumliche Klimadaten – Niederschlag, Temperatur, Sonnenschein
 ---
 
 # Bodengestützte räumliche Klimadaten – Niederschlag, Temperatur, Sonnenschein

--- a/i18n/de/docusaurus-plugin-content-docs/current/c-climate-data/c4-satellite-based-climate-data.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/c-climate-data/c4-satellite-based-climate-data.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+title: Satellitengestützte räumliche Klimadaten – Strahlung, Wolkenbedeckung
 ---
 
 # Satellitengestützte räumliche Klimadaten – Strahlung, Wolkenbedeckung

--- a/i18n/de/docusaurus-plugin-content-docs/current/c-climate-data/c5-radar-based-climate-data.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/c-climate-data/c5-radar-based-climate-data.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+title: Radargestützte räumliche Klimadaten – Hagel
 ---
 
 # Radargestützte räumliche Klimadaten – Hagel

--- a/i18n/de/docusaurus-plugin-content-docs/current/c-climate-data/c6-climate-normals.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/c-climate-data/c6-climate-normals.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+title: Klima-Normwerte
 ---
 
 # Klima-Normwerte

--- a/i18n/de/docusaurus-plugin-content-docs/current/c-climate-data/c7-spatial-climate-normals.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/c-climate-data/c7-spatial-climate-normals.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 7
+title: Räumliche Klima-Normwerte
 ---
 
 # Räumliche Klima-Normwerte

--- a/i18n/de/docusaurus-plugin-content-docs/current/c-climate-data/c8-climate-scenarios.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/c-climate-data/c8-climate-scenarios.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 8
+title: Klimaszenarien
 ---
 
 # Klimaszenarien

--- a/i18n/de/docusaurus-plugin-content-docs/current/c-climate-data/c9-spatial-climate-scenarios.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/c-climate-data/c9-spatial-climate-scenarios.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 9
+title: Räumliche Klimaszenarien
 ---
 
 # Räumliche Klimaszenarien

--- a/i18n/de/docusaurus-plugin-content-docs/current/d-radar-data/d1-precipitation-radar-products.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/d-radar-data/d1-precipitation-radar-products.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+title: Niederschlags-Radarprodukte
 ---
 
 # Niederschlags-Radarprodukte

--- a/i18n/de/docusaurus-plugin-content-docs/current/d-radar-data/d2-reflectivity-based-radar-products.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/d-radar-data/d2-reflectivity-based-radar-products.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+title: Reflektivitätsbasierte Radarprodukte
 ---
 
 # Reflektivitätsbasierte Radarprodukte

--- a/i18n/de/docusaurus-plugin-content-docs/current/d-radar-data/d3-hail-radar-products.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/d-radar-data/d3-hail-radar-products.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: Hagel-Radarprodukte
 ---
 
 # Hagel-Radarprodukte

--- a/i18n/de/docusaurus-plugin-content-docs/current/d-radar-data/d4-convection-radar-products.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/d-radar-data/d4-convection-radar-products.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+title: Convection radar products
 ---
 <!-- @NOSPELL@ -->
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/d-radar-data/d5-polar-3d-radar-products.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/d-radar-data/d5-polar-3d-radar-products.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+title: Polar 3D radar products
 ---
 <!-- @NOSPELL@ -->
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/e-forecast-data/e1-short-term-forecast-data.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/e-forecast-data/e1-short-term-forecast-data.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+title: Kurzfristprognosedaten
 ---
 
 # Kurzfristprognosedaten

--- a/i18n/de/docusaurus-plugin-content-docs/current/e-forecast-data/e2-e3-numerical-weather-forecasting-model.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/e-forecast-data/e2-e3-numerical-weather-forecasting-model.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+title: Numerisches Wettervorhersagemodell ICON-CH1/2-EPS
 ---
 
 # Numerisches Wettervorhersagemodell ICON-CH1/2-EPS

--- a/i18n/de/docusaurus-plugin-content-docs/current/e-forecast-data/e4-local-forecast-data.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/e-forecast-data/e4-local-forecast-data.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: Lokalprognosedaten
 ---
 
 # Lokalprognosedaten

--- a/i18n/de/docusaurus-plugin-content-docs/current/general/contact.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/general/contact.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+title: Kontakt
 ---
 
 # Kontakt

--- a/i18n/de/docusaurus-plugin-content-docs/current/general/download.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/general/download.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 2
+title: Daten herunterladen
 ---
+
 <!-- @NOSPELL@ -->
 
 # Daten herunterladen
@@ -10,6 +12,8 @@ sidebar_position: 2
 **Dieser Teil der Dokumentation** richtet sich primär an technische Nutzende und **liegt in Englisch vor**.
 
 :::
+
+
 
 ### Ground-based measurements
 MeteoSwiss primarily uses the [Federal Spatial Data Infrastructure FSDI](https://www.geo.admin.ch/en/federal-spatial-data-infrastructure-fsdi), which is operated by [swisstopo](https://www.swisstopo.admin.ch/en/coordination-geo-information-and-services-cogis).

--- a/i18n/de/docusaurus-plugin-content-docs/current/general/faq.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/general/faq.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+title: Häufig gestellte Fragen (FAQ)
 ---
 
 # Häufig gestellte Fragen (FAQ)

--- a/i18n/de/docusaurus-plugin-content-docs/current/general/status.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/general/status.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: Auf dem Laufenden bleiben
 ---
 
 # Auf dem Laufenden bleiben

--- a/i18n/de/docusaurus-plugin-content-docs/current/general/terms-of-use.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/general/terms-of-use.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+title: Nutzungsbedingungen
 ---
 
 # Nutzungsbedingungen

--- a/i18n/de/docusaurus-theme-classic/footer.json
+++ b/i18n/de/docusaurus-theme-classic/footer.json
@@ -1,8 +1,4 @@
 {
-  "link.title.Docs": {
-    "message": "Docs",
-    "description": "The title of the footer links column with title=Docs in the footer"
-  },
   "link.title.Contact": {
     "message": "Contact",
     "description": "The title of the footer links column with title=Contact in the footer"
@@ -11,28 +7,20 @@
     "message": "More",
     "description": "The title of the footer links column with title=More in the footer"
   },
-  "link.item.label.Data": {
-    "message": "Data",
-    "description": "The label of footer link with label=Data linking to /docs/data"
-  },
   "link.item.label.MeteoSwiss": {
     "message": "MeteoSwiss",
     "description": "The label of footer link with label=MeteoSwiss linking to https://www.meteoschweiz.admin.ch/ueber-uns/kontakt.html"
   },
-  "link.item.label.Blog": {
-    "message": "Blog",
-    "description": "The label of footer link with label=Blog linking to /blog"
+  "link.item.label.Changelog": {
+    "message": "Changelog",
+    "description": "The label of footer link with label=Changelog linking to /changelog"
   },
   "link.item.label.GitHub": {
     "message": "GitHub",
     "description": "The label of footer link with label=GitHub linking to https://github.com/MeteoSwiss/opendata"
   },
   "copyright": {
-    "message": "Copyright © 2024 Federal Office of Meteorology and Climatology MeteoSwiss. Built with Docusaurus.",
+    "message": "Copyright © 2025 Federal Office of Meteorology and Climatology MeteoSwiss.",
     "description": "The footer copyright"
-  },
-  "link.item.label.Changelog": {
-    "message": "Changelog",
-    "description": "The label of footer link with label=Changelog linking to /changelog"
   }
 }

--- a/i18n/de/docusaurus-theme-classic/navbar.json
+++ b/i18n/de/docusaurus-theme-classic/navbar.json
@@ -7,10 +7,6 @@
     "message": "MeteoSwiss - Logo",
     "description": "The alt text of navbar logo"
   },
-  "item.label.Data Documentation": {
-    "message": "Data Documentation",
-    "description": "Navbar item with label Data Documentation"
-  },
   "item.label.GitHub": {
     "message": "GitHub",
     "description": "Navbar item with label GitHub"

--- a/i18n/fr/docusaurus-plugin-content-docs/current/a-data-groundbased/a1-automatic-weather-stations.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/a-data-groundbased/a1-automatic-weather-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+title: Stations météorologiques automatiques
 ---
 
 # Stations météorologiques automatiques

--- a/i18n/fr/docusaurus-plugin-content-docs/current/a-data-groundbased/a2-automatic-precipitation-stations.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/a-data-groundbased/a2-automatic-precipitation-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+title: Stations pluviométriques automatiques
 ---
 
 # Stations pluviométriques automatiques

--- a/i18n/fr/docusaurus-plugin-content-docs/current/a-data-groundbased/a3-automatic-tower-stations.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/a-data-groundbased/a3-automatic-tower-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: Stations-tour automatiques
 ---
 
 # Stations-tour automatiques

--- a/i18n/fr/docusaurus-plugin-content-docs/current/a-data-groundbased/a4-automatic-soil-stations.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/a-data-groundbased/a4-automatic-soil-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+title: Stations d'humidité du sol automatiques
 ---
 
 # Stations d'humidité du sol automatiques

--- a/i18n/fr/docusaurus-plugin-content-docs/current/a-data-groundbased/a5-manual-precipitation-stations.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/a-data-groundbased/a5-manual-precipitation-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+title: Stations pluviométriques manuelles
 ---
 
 # Stations pluviométriques manuelles

--- a/i18n/fr/docusaurus-plugin-content-docs/current/a-data-groundbased/a6-totaliser-precipitation-stations.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/a-data-groundbased/a6-totaliser-precipitation-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+title: Stations pluviométriques totalisateur
 ---
 
 # Stations pluviométriques totalisateur

--- a/i18n/fr/docusaurus-plugin-content-docs/current/a-data-groundbased/a7-pollen-stations.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/a-data-groundbased/a7-pollen-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 7
+title: Stations pollen
 ---
 
 # Stations pollen

--- a/i18n/fr/docusaurus-plugin-content-docs/current/a-data-groundbased/a8-meteorological-visual-observations.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/a-data-groundbased/a8-meteorological-visual-observations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 8
+title: Observations visuelles météorologiques
 ---
 
 # Observations visuelles météorologiques

--- a/i18n/fr/docusaurus-plugin-content-docs/current/a-data-groundbased/a9-phenological-observations.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/a-data-groundbased/a9-phenological-observations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 9
+title: Observations phénologiques
 ---
 
 # Observations phénologiques

--- a/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b1-radio-sounding.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b1-radio-sounding.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+title: Radiosondages
 ---
 
 # Radiosondages

--- a/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b2-ralmo.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b2-ralmo.md
@@ -3,6 +3,8 @@ sidebar_position: 2
 title: Raman-LIDAR for Meteorological Observation (RALMO)
 ---
 
+<!-- @NOSPELL@ -->
+
 # Raman-LIDAR for Meteorological Observation (RALMO)
 
 :::warning

--- a/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b2-ralmo.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b2-ralmo.md
@@ -1,15 +1,14 @@
 ---
 sidebar_position: 2
+title: Raman-LIDAR for Meteorological Observation (RALMO)
 ---
-
-<!-- @NOSPELL@ -->
 
 # Raman-LIDAR for Meteorological Observation (RALMO)
 
-:::warning 
+:::warning
 
-Data is not yet available.
+Les données ne sont pas encore disponibles.
 
 :::
 
-Documentation follows.
+La documentation suivra.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b3-lidar-ceilometer-chm15k.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b3-lidar-ceilometer-chm15k.md
@@ -3,6 +3,8 @@ sidebar_position: 3
 title: LIDAR Ceilometer CHM15K
 ---
 
+<!-- @NOSPELL@ -->
+
 # LIDAR Ceilometer CHM15K
 
 :::warning

--- a/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b3-lidar-ceilometer-chm15k.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b3-lidar-ceilometer-chm15k.md
@@ -1,15 +1,14 @@
 ---
 sidebar_position: 3
+title: LIDAR Ceilometer CHM15K
 ---
-
-<!-- @NOSPELL@ -->
 
 # LIDAR Ceilometer CHM15K
 
-:::warning 
+:::warning
 
-Data is not yet available.
+Les données ne sont pas encore disponibles.
 
 :::
 
-Documentation follows.
+La documentation suivra.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b4-ozone-measurements-total-column.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b4-ozone-measurements-total-column.md
@@ -1,15 +1,14 @@
 ---
 sidebar_position: 3
+title: Ozone measurements – Total column (Dobson, Brewer)
 ---
-
-<!-- @NOSPELL@ -->
 
 # Ozone measurements – Total column (Dobson, Brewer)
 
-:::warning 
+:::warning
 
-Data is not yet available.
+Les données ne sont pas encore disponibles.
 
 :::
 
-Documentation follows.
+La documentation suivra.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b4-ozone-measurements-total-column.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b4-ozone-measurements-total-column.md
@@ -3,6 +3,8 @@ sidebar_position: 3
 title: Ozone measurements – Total column (Dobson, Brewer)
 ---
 
+<!-- @NOSPELL@ -->
+
 # Ozone measurements – Total column (Dobson, Brewer)
 
 :::warning

--- a/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b5-ozone-measurements-profiles.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b5-ozone-measurements-profiles.md
@@ -1,15 +1,14 @@
 ---
 sidebar_position: 3
+title: Ozone measurements – Profiles (O3 radio soundings, SOMORA)
 ---
-
-<!-- @NOSPELL@ -->
 
 # Ozone measurements – Profiles (O3 radio soundings, SOMORA)
 
-:::warning 
+:::warning
 
-Data is not yet available.
+Les données ne sont pas encore disponibles.
 
 :::
 
-Documentation follows.
+La documentation suivra.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b5-ozone-measurements-profiles.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b5-ozone-measurements-profiles.md
@@ -3,6 +3,8 @@ sidebar_position: 3
 title: Ozone measurements – Profiles (O3 radio soundings, SOMORA)
 ---
 
+<!-- @NOSPELL@ -->
+
 # Ozone measurements – Profiles (O3 radio soundings, SOMORA)
 
 :::warning

--- a/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b6-sacram.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b6-sacram.md
@@ -1,14 +1,14 @@
 ---
 sidebar_position: 3
+title: Swiss Alpine Climate Radiation Monitoring (SACRaM)
 ---
-<!-- @NOSPELL@ -->
 
 # Swiss Alpine Climate Radiation Monitoring (SACRaM)
 
-:::warning 
+:::warning
 
-Data is not yet available.
+Les données ne sont pas encore disponibles.
 
 :::
 
-Documentation follows.
+La documentation suivra.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b6-sacram.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/b-data-atmosphere/b6-sacram.md
@@ -3,6 +3,8 @@ sidebar_position: 3
 title: Swiss Alpine Climate Radiation Monitoring (SACRaM)
 ---
 
+<!-- @NOSPELL@ -->
+
 # Swiss Alpine Climate Radiation Monitoring (SACRaM)
 
 :::warning

--- a/i18n/fr/docusaurus-plugin-content-docs/current/c-climate-data/c1-climate-stations_homogeneous.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/c-climate-data/c1-climate-stations_homogeneous.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+title: Stations climatologiques – Séries de mesures homogènes
 ---
 
 # Stations climatologiques – Séries de mesures homogènes

--- a/i18n/fr/docusaurus-plugin-content-docs/current/c-climate-data/c2-climate-percipitation-stations_homogeneous.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/c-climate-data/c2-climate-percipitation-stations_homogeneous.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+title: Stations climatologiques pluviométriques – Séries de mesures homogènes
 ---
 
 # Stations climatologiques pluviométriques – Séries de mesures homogènes

--- a/i18n/fr/docusaurus-plugin-content-docs/current/c-climate-data/c3-ground-based-climate-data.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/c-climate-data/c3-ground-based-climate-data.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: Données climatiques spatiales basées sur les mesures au sol –  Précipitations, température, ensoleillement
 ---
 
 # Données climatiques spatiales basées sur les mesures au sol –  Précipitations, température, ensoleillement

--- a/i18n/fr/docusaurus-plugin-content-docs/current/c-climate-data/c4-satellite-based-climate-data.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/c-climate-data/c4-satellite-based-climate-data.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+title: Données climatiques spatiales par satellite – Rayonnement, couverture nuageuse
 ---
 
 # Données climatiques spatiales par satellite – Rayonnement, couverture nuageuse

--- a/i18n/fr/docusaurus-plugin-content-docs/current/c-climate-data/c5-radar-based-climate-data.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/c-climate-data/c5-radar-based-climate-data.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+title: Données climatiques spatiales basées sur les radars – Grêle
 ---
 
 # Données climatiques spatiales basées sur les radars – Grêle

--- a/i18n/fr/docusaurus-plugin-content-docs/current/c-climate-data/c6-climate-normals.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/c-climate-data/c6-climate-normals.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+title: Normes climatologiques
 ---
 
 # Normes climatologiques

--- a/i18n/fr/docusaurus-plugin-content-docs/current/c-climate-data/c7-spatial-climate-normals.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/c-climate-data/c7-spatial-climate-normals.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 7
+title: Normes climatologiques spatiales
 ---
 
 # Normes climatologiques spatiales

--- a/i18n/fr/docusaurus-plugin-content-docs/current/c-climate-data/c8-climate-scenarios.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/c-climate-data/c8-climate-scenarios.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 8
+title: Scénarios climatiques
 ---
 
 # Scénarios climatiques

--- a/i18n/fr/docusaurus-plugin-content-docs/current/c-climate-data/c9-spatial-climate-scenarios.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/c-climate-data/c9-spatial-climate-scenarios.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 9
+title: Scénarios climatiques spatiales
 ---
 
 # Scénarios climatiques spatiales

--- a/i18n/fr/docusaurus-plugin-content-docs/current/d-radar-data/d1-precipitation-radar-products.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/d-radar-data/d1-precipitation-radar-products.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+title: Produits radar de précipitation
 ---
 
 # Produits radar de précipitation

--- a/i18n/fr/docusaurus-plugin-content-docs/current/d-radar-data/d2-reflectivity-based-radar-products.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/d-radar-data/d2-reflectivity-based-radar-products.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+title: Produits radar basés sur la réflectivité
 ---
 
 # Produits radar basés sur la réflectivité

--- a/i18n/fr/docusaurus-plugin-content-docs/current/d-radar-data/d3-hail-radar-products.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/d-radar-data/d3-hail-radar-products.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: Produits radar de grêle
 ---
 
 # Produits radar de grêle

--- a/i18n/fr/docusaurus-plugin-content-docs/current/d-radar-data/d4-convection-radar-products.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/d-radar-data/d4-convection-radar-products.md
@@ -3,6 +3,8 @@ sidebar_position: 4
 title: Convection radar products
 ---
 
+<!-- @NOSPELL@ -->
+
 # Convection radar products
 
 :::warning

--- a/i18n/fr/docusaurus-plugin-content-docs/current/d-radar-data/d4-convection-radar-products.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/d-radar-data/d4-convection-radar-products.md
@@ -1,13 +1,14 @@
 ---
 sidebar_position: 4
+title: Convection radar products
 ---
 
-<!-- @NOSPELL@ -->
-
-# D4 - Convection radar products
+# Convection radar products
 
 :::warning
 
-*(not yet realised)*
+Les données ne sont pas encore disponibles.
 
 :::
+
+La documentation suivra.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/d-radar-data/d5-polar-3d-radar-products.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/d-radar-data/d5-polar-3d-radar-products.md
@@ -1,13 +1,14 @@
 ---
 sidebar_position: 5
+title: Polar 3D radar products
 ---
 
-<!-- @NOSPELL@ -->
-
-# D5 - Polar 3D radar products
+# Polar 3D radar products
 
 :::warning
 
-*(not yet realised)*
+Les données ne sont pas encore disponibles.
 
 :::
+
+La documentation suivra.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/d-radar-data/d5-polar-3d-radar-products.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/d-radar-data/d5-polar-3d-radar-products.md
@@ -3,6 +3,8 @@ sidebar_position: 5
 title: Polar 3D radar products
 ---
 
+<!-- @NOSPELL@ -->
+
 # Polar 3D radar products
 
 :::warning

--- a/i18n/fr/docusaurus-plugin-content-docs/current/e-forecast-data/e1-short-term-forecast-data.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/e-forecast-data/e1-short-term-forecast-data.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+title: Données de prévisions à court terme
 ---
 
 # Données de prévisions à court terme

--- a/i18n/fr/docusaurus-plugin-content-docs/current/e-forecast-data/e2-e3-numerical-weather-forecasting-model.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/e-forecast-data/e2-e3-numerical-weather-forecasting-model.md
@@ -1,7 +1,10 @@
 ---
 sidebar_position: 2
+title: Modèle numérique de prévision météorologique ICON-CH1/2-EPS
 ---
 
 # Modèle numérique de prévision météorologique ICON-CH1/2-EPS
 
 Vers [la documentation en anglais](https://opendatadocs.meteoswiss.ch/e-forecast-data/e2-e3-numerical-weather-forecasting-model).
+
+La traduction suivra.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/e-forecast-data/e4-local-forecast-data.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/e-forecast-data/e4-local-forecast-data.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: Données de prévisions par localité
 ---
 
 # Données de prévisions par localité

--- a/i18n/fr/docusaurus-plugin-content-docs/current/general/contact.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/general/contact.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+title: Contact
 ---
 
 # Contact

--- a/i18n/fr/docusaurus-plugin-content-docs/current/general/download.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/general/download.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+title: Télécharger les données
 ---
 
 # Télécharger les données

--- a/i18n/fr/docusaurus-plugin-content-docs/current/general/faq.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/general/faq.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+title: Questions fréquentes (FAQ)
 ---
 
 # Questions fréquentes (FAQ)

--- a/i18n/fr/docusaurus-plugin-content-docs/current/general/status.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/general/status.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: Restez à jour
 ---
 
 # Restez à jour

--- a/i18n/fr/docusaurus-plugin-content-docs/current/general/terms-of-use.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/general/terms-of-use.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+title: Conditions d'utilisation
 ---
 
 # Conditions d'utilisation

--- a/i18n/it/docusaurus-plugin-content-docs/current/a-data-groundbased/a1-automatic-weather-stations.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/a-data-groundbased/a1-automatic-weather-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+title: Stazioni meteorologiche automatiche
 ---
 
 # Stazioni meteorologiche automatiche

--- a/i18n/it/docusaurus-plugin-content-docs/current/a-data-groundbased/a2-automatic-precipitation-stations.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/a-data-groundbased/a2-automatic-precipitation-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+title: Stazioni pluviometriche automatiche
 ---
 
 # Stazioni pluviometriche automatiche

--- a/i18n/it/docusaurus-plugin-content-docs/current/a-data-groundbased/a3-automatic-tower-stations.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/a-data-groundbased/a3-automatic-tower-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: Stazioni automatiche posizionate su una torre
 ---
 
 # Stazioni automatiche posizionate su una torre

--- a/i18n/it/docusaurus-plugin-content-docs/current/a-data-groundbased/a4-automatic-soil-stations.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/a-data-groundbased/a4-automatic-soil-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+title: Stazioni d'umidità del suolo automatiche
 ---
 
 # Stazioni d'umidità del suolo automatiche

--- a/i18n/it/docusaurus-plugin-content-docs/current/a-data-groundbased/a5-manual-precipitation-stations.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/a-data-groundbased/a5-manual-precipitation-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+title: Stazioni pluviometriche manuali
 ---
 
 # Stazioni pluviometriche manuali

--- a/i18n/it/docusaurus-plugin-content-docs/current/a-data-groundbased/a6-totaliser-precipitation-stations.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/a-data-groundbased/a6-totaliser-precipitation-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+title: Pluviometri totalizzatori
 ---
 
 # Pluviometri totalizzatori

--- a/i18n/it/docusaurus-plugin-content-docs/current/a-data-groundbased/a7-pollen-stations.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/a-data-groundbased/a7-pollen-stations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 7
+title: Stazioni pollini
 ---
 
 # Stazioni pollini

--- a/i18n/it/docusaurus-plugin-content-docs/current/a-data-groundbased/a8-meteorological-visual-observations.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/a-data-groundbased/a8-meteorological-visual-observations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 8
+title: Osservazioni visuale meteorologiche
 ---
 
 # Osservazioni visuale meteorologiche

--- a/i18n/it/docusaurus-plugin-content-docs/current/a-data-groundbased/a9-phenological-observations.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/a-data-groundbased/a9-phenological-observations.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 9
+title: Osservazioni fenologiche
 ---
 
 # Osservazioni fenologiche

--- a/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b1-radio-sounding.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b1-radio-sounding.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+title: Radiosondaggi
 ---
 
 # Radiosondaggi

--- a/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b2-ralmo.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b2-ralmo.md
@@ -3,6 +3,8 @@ sidebar_position: 2
 title: Raman-LIDAR for Meteorological Observation (RALMO)
 ---
 
+<!-- @NOSPELL@ -->
+
 # Raman-LIDAR for Meteorological Observation (RALMO)
 
 :::warning

--- a/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b2-ralmo.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b2-ralmo.md
@@ -1,15 +1,14 @@
 ---
 sidebar_position: 2
+title: Raman-LIDAR for Meteorological Observation (RALMO)
 ---
-
-<!-- @NOSPELL@ -->
 
 # Raman-LIDAR for Meteorological Observation (RALMO)
 
-:::warning 
+:::warning
 
-Data is not yet available.
+I dati non sono ancora disponibili.
 
 :::
 
-Documentation follows.
+La documentazione seguirà.

--- a/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b3-lidar-ceilometer-chm15k.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b3-lidar-ceilometer-chm15k.md
@@ -1,15 +1,14 @@
 ---
 sidebar_position: 3
+title: LIDAR Ceilometer CHM15K
 ---
-
-<!-- @NOSPELL@ -->
 
 # LIDAR Ceilometer CHM15K
 
-:::warning 
+:::warning
 
-Data is not yet available.
+I dati non sono ancora disponibili.
 
 :::
 
-Documentation follows.
+La documentazione seguirà.

--- a/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b3-lidar-ceilometer-chm15k.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b3-lidar-ceilometer-chm15k.md
@@ -3,6 +3,8 @@ sidebar_position: 3
 title: LIDAR Ceilometer CHM15K
 ---
 
+<!-- @NOSPELL@ -->
+
 # LIDAR Ceilometer CHM15K
 
 :::warning

--- a/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b4-ozone-measurements-total-column.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b4-ozone-measurements-total-column.md
@@ -1,15 +1,14 @@
 ---
 sidebar_position: 3
+title: Ozone measurements – Total column (Dobson, Brewer)
 ---
-
-<!-- @NOSPELL@ -->
 
 # Ozone measurements – Total column (Dobson, Brewer)
 
-:::warning 
+:::warning
 
-Data is not yet available.
+I dati non sono ancora disponibili.
 
 :::
 
-Documentation follows.
+La documentazione seguirà.

--- a/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b4-ozone-measurements-total-column.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b4-ozone-measurements-total-column.md
@@ -3,6 +3,8 @@ sidebar_position: 3
 title: Ozone measurements – Total column (Dobson, Brewer)
 ---
 
+<!-- @NOSPELL@ -->
+
 # Ozone measurements – Total column (Dobson, Brewer)
 
 :::warning

--- a/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b5-ozone-measurements-profiles.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b5-ozone-measurements-profiles.md
@@ -1,15 +1,14 @@
 ---
 sidebar_position: 3
+title: Ozone measurements – Profiles (O3 radio soundings, SOMORA)
 ---
-
-<!-- @NOSPELL@ -->
 
 # Ozone measurements – Profiles (O3 radio soundings, SOMORA)
 
-:::warning 
+:::warning
 
-Data is not yet available.
+I dati non sono ancora disponibili.
 
 :::
 
-Documentation follows.
+La documentazione seguirà.

--- a/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b5-ozone-measurements-profiles.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b5-ozone-measurements-profiles.md
@@ -3,6 +3,8 @@ sidebar_position: 3
 title: Ozone measurements – Profiles (O3 radio soundings, SOMORA)
 ---
 
+<!-- @NOSPELL@ -->
+
 # Ozone measurements – Profiles (O3 radio soundings, SOMORA)
 
 :::warning

--- a/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b6-sacram.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b6-sacram.md
@@ -3,6 +3,8 @@ sidebar_position: 3
 title: Swiss Alpine Climate Radiation Monitoring (SACRaM)
 ---
 
+<!-- @NOSPELL@ -->
+
 # Swiss Alpine Climate Radiation Monitoring (SACRaM)
 
 :::warning

--- a/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b6-sacram.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/b-data-atmosphere/b6-sacram.md
@@ -1,15 +1,14 @@
 ---
 sidebar_position: 3
+title: Swiss Alpine Climate Radiation Monitoring (SACRaM)
 ---
-
-<!-- @NOSPELL@ -->
 
 # Swiss Alpine Climate Radiation Monitoring (SACRaM)
 
-:::warning 
+:::warning
 
-Data is not yet available.
+I dati non sono ancora disponibili.
 
 :::
 
-Documentation follows.
+La documentazione seguirà.

--- a/i18n/it/docusaurus-plugin-content-docs/current/c-climate-data/c1-climate-stations_homogeneous.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/c-climate-data/c1-climate-stations_homogeneous.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+title: Stazioni climatologiche – Serie omogenee di misurazioni
 ---
 
 # Stazioni climatologiche – Serie omogenee di misurazioni

--- a/i18n/it/docusaurus-plugin-content-docs/current/c-climate-data/c2-climate-percipitation-stations_homogeneous.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/c-climate-data/c2-climate-percipitation-stations_homogeneous.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+title: Stazioni climatologiche pluviometriche – Serie omogenee di misurazioni
 ---
 
 # Stazioni climatologiche pluviometriche – Serie omogenee di misurazioni

--- a/i18n/it/docusaurus-plugin-content-docs/current/c-climate-data/c3-ground-based-climate-data.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/c-climate-data/c3-ground-based-climate-data.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: Dati climatici spaziali basati sulle misure al suolo – Precipitazioni, temperatura, soleggiamento
 ---
 
 # Dati climatici spaziali basati sulle misure al suolo – Precipitazioni, temperatura, soleggiamento

--- a/i18n/it/docusaurus-plugin-content-docs/current/c-climate-data/c4-satellite-based-climate-data.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/c-climate-data/c4-satellite-based-climate-data.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+title: Dati climatici spaziali basati sulle misure satellitari – Radiazione, copertura nuvolosa
 ---
 
 # Dati climatici spaziali basati sulle misure satellitari – Radiazione, copertura nuvolosa

--- a/i18n/it/docusaurus-plugin-content-docs/current/c-climate-data/c5-radar-based-climate-data.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/c-climate-data/c5-radar-based-climate-data.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+title: Dati climatici spaziali basati su radar – Grandine
 ---
 
 # Dati climatici spaziali basati su radar – Grandine

--- a/i18n/it/docusaurus-plugin-content-docs/current/c-climate-data/c6-climate-normals.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/c-climate-data/c6-climate-normals.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+title: Norme climatiche
 ---
 
 # Norme climatiche

--- a/i18n/it/docusaurus-plugin-content-docs/current/c-climate-data/c7-spatial-climate-normals.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/c-climate-data/c7-spatial-climate-normals.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 7
+title: Norme climatiche spaziali
 ---
 
 # Norme climatiche spaziali

--- a/i18n/it/docusaurus-plugin-content-docs/current/c-climate-data/c8-climate-scenarios.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/c-climate-data/c8-climate-scenarios.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 8
+title: Scenari climatici
 ---
 
 # Scenari climatici

--- a/i18n/it/docusaurus-plugin-content-docs/current/c-climate-data/c9-spatial-climate-scenarios.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/c-climate-data/c9-spatial-climate-scenarios.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 9
+title: Scenari climatici spaziali
 ---
 
 # Scenari climatici spaziali

--- a/i18n/it/docusaurus-plugin-content-docs/current/d-radar-data/d1-precipitation-radar-products.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/d-radar-data/d1-precipitation-radar-products.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+title: Prodotti radar – Precipitazioni
 ---
 
 # Prodotti radar – Precipitazioni

--- a/i18n/it/docusaurus-plugin-content-docs/current/d-radar-data/d2-reflectivity-based-radar-products.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/d-radar-data/d2-reflectivity-based-radar-products.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+title: Prodotti radar – Riflettività
 ---
 
 # Prodotti radar – Riflettività

--- a/i18n/it/docusaurus-plugin-content-docs/current/d-radar-data/d3-hail-radar-products.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/d-radar-data/d3-hail-radar-products.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: Prodotti radar – Grandine
 ---
 
 # Prodotti radar – Grandine

--- a/i18n/it/docusaurus-plugin-content-docs/current/d-radar-data/d4-convection-radar-products.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/d-radar-data/d4-convection-radar-products.md
@@ -3,6 +3,8 @@ sidebar_position: 4
 title: Convection radar products
 ---
 
+<!-- @NOSPELL@ -->
+
 # Convection radar products
 
 :::warning

--- a/i18n/it/docusaurus-plugin-content-docs/current/d-radar-data/d4-convection-radar-products.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/d-radar-data/d4-convection-radar-products.md
@@ -1,13 +1,14 @@
 ---
 sidebar_position: 4
+title: Convection radar products
 ---
 
-<!-- @NOSPELL@ -->
-
-# D4 - Convection radar products
+# Convection radar products
 
 :::warning
 
-*(not yet realised)*
+I dati non sono ancora disponibili.
 
 :::
+
+La documentazione seguirà.

--- a/i18n/it/docusaurus-plugin-content-docs/current/d-radar-data/d5-polar-3d-radar-products.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/d-radar-data/d5-polar-3d-radar-products.md
@@ -3,6 +3,8 @@ sidebar_position: 5
 title: Polar 3D radar products
 ---
 
+<!-- @NOSPELL@ -->
+
 # Polar 3D radar products
 
 :::warning

--- a/i18n/it/docusaurus-plugin-content-docs/current/d-radar-data/d5-polar-3d-radar-products.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/d-radar-data/d5-polar-3d-radar-products.md
@@ -1,13 +1,14 @@
 ---
 sidebar_position: 5
+title: Polar 3D radar products
 ---
 
-<!-- @NOSPELL@ -->
-
-# D5 - Polar 3D radar products
+# Polar 3D radar products
 
 :::warning
 
-*(not yet realised)*
+I dati non sono ancora disponibili.
 
 :::
+
+La documentazione seguirà.

--- a/i18n/it/docusaurus-plugin-content-docs/current/e-forecast-data/e1-short-term-forecast-data.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/e-forecast-data/e1-short-term-forecast-data.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+title: Dati di previsione a breve termine
 ---
 
 # Dati di previsione a breve termine

--- a/i18n/it/docusaurus-plugin-content-docs/current/e-forecast-data/e2-e3-numerical-weather-forecasting-model.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/e-forecast-data/e2-e3-numerical-weather-forecasting-model.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+title: Modello numerico di previsione meteorologica ICON-CH1/2-EPS
 ---
 
 # Modello numerico di previsione meteorologica ICON-CH1/2-EPS

--- a/i18n/it/docusaurus-plugin-content-docs/current/e-forecast-data/e4-local-forecast-data.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/e-forecast-data/e4-local-forecast-data.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: Dati delle previsioni locali
 ---
 
 # Dati delle previsioni locali

--- a/i18n/it/docusaurus-plugin-content-docs/current/general/contact.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/general/contact.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+title: Contatti
 ---
 
 # Contatti

--- a/i18n/it/docusaurus-plugin-content-docs/current/general/download.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/general/download.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+title: Scaricare i dati
 ---
 
 # Scaricare i dati

--- a/i18n/it/docusaurus-plugin-content-docs/current/general/faq.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/general/faq.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+title: Domande frequenti (FAQ)
 ---
 
 # Domande frequenti (FAQ)

--- a/i18n/it/docusaurus-plugin-content-docs/current/general/status.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/general/status.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: Rimanere aggiornati
 ---
 
 # Rimanere aggiornati

--- a/i18n/it/docusaurus-plugin-content-docs/current/general/terms-of-use.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/general/terms-of-use.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+title: Condizioni di utilizzo
 ---
 
 # Condizioni di utilizzo


### PR DESCRIPTION
Docusaurus tries to find the title of a page by using the first heading in the file.

Since the spellchecker was added, some files have the special tag `<!-- @NOSPELL@ -->` on top, so this mechanism doesn't always work. This led to "missing" traslations in the sidebar (e.g. in German "download" instead of "Daten herunterladen"). By adding the title to the metadata (i.e. the `---`-part on top of each markdown file) of each page, this problem can be resolved.