### PR TITLE
Add explicit heading id for anchors

### DIFF
--- a/docs/a-data-groundbased/a2-automatic-precipitation-stations.md
+++ b/docs/a-data-groundbased/a2-automatic-precipitation-stations.md
@@ -8,13 +8,13 @@ As a meteorological parameter, precipitation exhibits a very high spatial variab
 
 They deliver precipitation – every 10 minutes.
 
-## Data download
+## Data download {#data-download}
 
 The Open Data from MeteoSwiss may be used without restriction; the **source must be cited** when reproducing or redistributing ("**Source: MeteoSwiss**").
 
 :white_check_mark: By using 'Open Data' from MeteoSchweiz, you confirm that you have taken note of the [Terms of use](/general/terms-of-use).
 
-### Download data automatically
+### Download data automatically {#download-data-automatically}
 
 Download **files per station** automatically via FSDI's REST API: [`https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-smn-precip`](https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-smn-precip)
 
@@ -22,11 +22,11 @@ Read our [documentation on how to download files automatically](/general/downloa
 
 The STAC Browser can be a useful tool to facilitate the use of the API: [`https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.ogd-smn-precip`](https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.ogd-smn-precip)
 
-### Download data manually
+### Download data manually {#download-data-manually}
 
 Select and download **files per station** manually via MeteoSwiss' [Open Data Explorer](https://www.meteoswiss.admin.ch/services-and-publications/applications/ext/download-data-without-coding-skills.html#lang=en&mdt=normal&pgid=Precipitation&sid=&col=&di=&tr=&hdr=).
 
-## Data structure
+## Data structure {#data-structure}
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -45,11 +45,11 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data format
+## Data format {#data-format}
 
 [`CSV`](https://opendatadocs.meteoswiss.ch/general/download#column-separators-and-decimal-dividers) with an estimated volume of ≤5.3 MB per file.
 
-## Metadata
+## Metadata {#metadata}
 
 <Tabs queryString="metadata">
   <TabItem value="parameters" label="Parameter">
@@ -67,7 +67,7 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data usage
+## Data usage {#data-usage}
 
 See e.g. MeteoSwiss' [SwissMetNet network map](https://www.meteoswiss.admin.ch/services-and-publications/applications/measurement-values-and-measuring-networks.html#param=messnetz-automatisch&lang=en).
 

--- a/docs/a-data-groundbased/a3-automatic-tower-stations.md
+++ b/docs/a-data-groundbased/a3-automatic-tower-stations.md
@@ -10,13 +10,13 @@ They deliver temperature, wind, sunshine, humidity and radiation <!-- and pressu
 
 <!-- To do: describe particularities of station PSI -->
 
-## Data download
+## Data download {#data-download}
 
 The Open Data from MeteoSwiss may be used without restriction; the **source must be cited** when reproducing or redistributing ("**Source: MeteoSwiss**").
 
 :white_check_mark: By using 'Open Data' from MeteoSchweiz, you confirm that you have taken note of the [Terms of use](/general/terms-of-use).
 
-### Download data automatically
+### Download data automatically {#download-data-automatically}
 
 Download **files per station** automatically via FSDI's REST API: [`https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-smn-tower`](https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-smn-tower)
 
@@ -24,11 +24,11 @@ Read our [documentation on how to download files automatically](/general/downloa
 
 The STAC Browser can be a useful tool to facilitate the use of the API: [`https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.ogd-smn-tower`](https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.ogd-smn-tower)
 
-### Download data manually
+### Download data manually {#download-data-manually}
 
 Select and download **files per station** manually via MeteoSwiss' [Open Data Explorer](https://www.meteoswiss.admin.ch/services-and-publications/applications/ext/download-data-without-coding-skills.html#lang=en&mdt=normal&pgid=&sid=&col=&di=&tr=&hdr=).
 
-## Data structure
+## Data structure {#data-structure}
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -47,11 +47,11 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data format
+## Data format {#data-format}
 
 [`CSV`](https://opendatadocs.meteoswiss.ch/general/download#column-separators-and-decimal-dividers) with an estimated volume of ≤5.3 MB per file.
 
-## Metadata
+## Metadata {#metadata}
 
 <Tabs queryString="metadata">
   <TabItem value="parameters" label="Parameter">
@@ -69,7 +69,7 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data usage
+## Data usage {#data-usage}
 
 See e.g. MeteoSwiss' [SwissMetNet network map](https://www.meteoswiss.admin.ch/services-and-publications/applications/measurement-values-and-measuring-networks.html#param=messnetz-automatisch&lang=en).
 

--- a/docs/a-data-groundbased/a5-manual-precipitation-stations.md
+++ b/docs/a-data-groundbased/a5-manual-precipitation-stations.md
@@ -12,13 +12,13 @@ Due to their long-series measurements, they are of great climatological signific
 
 In mountainous areas that are difficult to access, the network is supplemented by around 60 totalisers which record the volume of precipitation for an entire year (see [Totaliser precipitation stations](https://opendatadocs.meteoswiss.ch/a-data-groundbased/a6-totaliser-precipitation-stations)).
 
-## Data download
+## Data download {#data-download}
 
 The Open Data from MeteoSwiss may be used without restriction; the **source must be cited** when reproducing or redistributing ("**Source: MeteoSwiss**").
 
 :white_check_mark: By using 'Open Data' from MeteoSchweiz, you confirm that you have taken note of the [Terms of use](/general/terms-of-use).
 
-### Download data automatically
+### Download data automatically {#download-data-automatically}
 
 Download **files per station** automatically via FSDI's REST API: [`https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-nime`](https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-nime)
 
@@ -26,11 +26,11 @@ Read our [documentation on how to download files automatically](/general/downloa
 
 The STAC Browser can be a useful tool to facilitate the use of the API: [`https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.ogd-nime`](https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.ogd-nime)
 
-### Download data manually
+### Download data manually {#download-data-manually}
 
 Select and download **files per station** manually via MeteoSwiss' [Open Data Explorer](https://www.meteoswiss.admin.ch/services-and-publications/applications/ext/download-data-without-coding-skills.html#lang=en&mdt=normal&pgid=&sid=&col=&di=&tr=&hdr=).
 
-## Data structure
+## Data structure {#data-structure}
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -47,11 +47,11 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data format
+## Data format {#data-format}
 
 [`CSV`](https://opendatadocs.meteoswiss.ch/general/download#column-separators-and-decimal-dividers) with an estimated volume of ≤0.6 MB per file.
 
-## Metadata
+## Metadata {#metadata}
 
 <Tabs queryString="metadata">
   <TabItem value="parameters" label="Parameter">
@@ -69,7 +69,7 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data usage
+## Data usage {#data-usage}
 
 See e.g. MeteoSwiss' [SwissMetNet network map](https://www.meteoswiss.admin.ch/services-and-publications/applications/measurement-values-and-measuring-networks.html#param=messnetz-manuell&lang=en&table=false).
 

--- a/docs/a-data-groundbased/a6-totaliser-precipitation-stations.md
+++ b/docs/a-data-groundbased/a6-totaliser-precipitation-stations.md
@@ -12,13 +12,13 @@ Totaliser precipitation data cover a so-called 'hydrological year', i.e. from 1 
 
 :::
 
-## Data download
+## Data download {#data-download}
 
 The Open Data from MeteoSwiss may be used without restriction; the **source must be cited** when reproducing or redistributing ("**Source: MeteoSwiss**").
 
 :white_check_mark: By using 'Open Data' from MeteoSchweiz, you confirm that you have taken note of the [Terms of use](/general/terms-of-use).
 
-### Download data automatically
+### Download data automatically {#download-data-automatically}
 
 Download **files per station** automatically via FSDI's REST API: [`https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-tot`](https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-tot)
 
@@ -26,11 +26,11 @@ Read our [information on how you can obtain data automatically](/general/downloa
 
 The STAC Browser can be a useful tool to facilitate the use of the API: [`https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.ogd-tot`](https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.ogd-tot)
 
-### Download data manually
+### Download data manually {#download-data-manually}
 
 Select and download **files per station** manually via MeteoSwiss' [Open Data Explorer](https://www.meteoswiss.admin.ch/services-and-publications/applications/ext/download-data-without-coding-skills.html#lang=en&mdt=normal&pgid=Precipitation&sid=&col=&di=&tr=&hdr=).
 
-## Data structure
+## Data structure {#data-structure}
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -43,11 +43,11 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data format
+## Data format {#data-format}
 
 [`CSV`](https://opendatadocs.meteoswiss.ch/general/download#column-separators-and-decimal-dividers) with an estimated volume of ≤0.6 MB per file.
 
-## Metadata
+## Metadata {#metadata}
 
 <Tabs queryString="metadata">
   <TabItem value="parameters" label="Parameter">
@@ -65,7 +65,7 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data usage
+## Data usage {#data-usage}
 
 See e.g. MeteoSwiss' [SwissMetNet network map](https://www.meteoswiss.admin.ch/services-and-publications/applications/measurement-values-and-measuring-networks.html#param=messnetz-manuell&lang=en&table=false). 
 

--- a/docs/a-data-groundbased/a7-pollen-stations.md
+++ b/docs/a-data-groundbased/a7-pollen-stations.md
@@ -12,13 +12,13 @@ The manual and the automatic data may differ in terms of the concentration inten
 
 The scientific names of the plants are available in the English version of the documents.
 
-## Data download
+## Data download {#data-download}
 
 The Open Data from MeteoSwiss may be used without restriction; the **source must be cited** when reproducing or redistributing ("**Source: MeteoSwiss**").
 
 :white_check_mark: By using 'Open Data' from MeteoSchweiz, you confirm that you have taken note of the [Terms of use](/general/terms-of-use).
 
-### Download data automatically
+### Download data automatically {#download-data-automatically}
 
 Download **files per station** automatically via FSDI's REST API: [`https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-pollen`](https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-pollen)
 
@@ -26,11 +26,11 @@ Read our [information on how you can obtain data automatically](/general/downloa
 
 The STAC Browser can be a useful tool to facilitate the use of the API: [`https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.ogd-pollen`](https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.ogd-pollen)
 
-### Download data manually
+### Download data manually {#download-data-manually}
 
 Select and download **files per station** manually via MeteoSwiss' [Open Data Explorer](https://www.meteoswiss.admin.ch/services-and-publications/applications/ext/download-data-without-coding-skills.html#lang=en&mdt=normal&pgid=Pollen&sid=&col=&di=&tr=&hdr=).
 
-## Data structure
+## Data structure {#data-structure}
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -53,11 +53,11 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data format
+## Data format {#data-format}
 
 [`CSV`](https://opendatadocs.meteoswiss.ch/general/download#column-separators-and-decimal-dividers) with an estimated volume of ≤0.6 MB per file.
 
-## Metadata
+## Metadata {#metadata}
 
 <Tabs queryString="metadata">
   <TabItem value="parameters" label="Parameter">
@@ -75,6 +75,6 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data usage
+## Data usage {#data-usage}
 
 See e.g. MeteoSwiss' [POLLEN network map](https://www.meteoswiss.admin.ch/services-and-publications/applications/measurement-values-and-measuring-networks.html#param=messnetz-pollen&lang=en&table=false&station=PLZ&chart=day).

--- a/docs/a-data-groundbased/a8-meteorological-visual-observations.md
+++ b/docs/a-data-groundbased/a8-meteorological-visual-observations.md
@@ -13,13 +13,13 @@ Meteorological observers make visual observations and take readings from measure
 - Clouds: extent of total cloud cover, type and shape of visible clouds, the altitude of the cloud base
 - Measurement of fresh and total snow depth *[to be verified]*
 
-## Data download
+## Data download {#data-download}
 
 The Open Data from MeteoSwiss may be used without restriction; the **source must be cited** when reproducing or redistributing ("**Source: MeteoSwiss**").
 
 :white_check_mark: By using 'Open Data' from MeteoSchweiz, you confirm that you have taken note of the [Terms of use](/general/terms-of-use).
 
-### Download data automatically
+### Download data automatically {#download-data-automatically}
 
 Download **files per station** automatically via FSDI's REST API: [`https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-obs`](https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-obs)
 
@@ -27,11 +27,11 @@ Read our [information on how you can obtain data automatically](/general/downloa
 
 The STAC Browser can be a useful tool to facilitate the use of the API: [`https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.ogd-obs`](https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.ogd-obs)
 
-### Download data manually
+### Download data manually {#download-data-manually}
 
 Select and download **files per station** manually via MeteoSwiss' [Open Data Explorer](https://www.meteoswiss.admin.ch/services-and-publications/applications/ext/download-data-without-coding-skills.html#lang=en&mdt=normal&pgid=Visual+observation&sid=&col=&di=&tr=&hdr=).
 
-## Data structure
+## Data structure {#data-structure}
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -48,11 +48,11 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data format
+## Data format {#data-format}
 
 [`CSV`](https://opendatadocs.meteoswiss.ch/general/download#column-separators-and-decimal-dividers) with an estimated volume of ≤0.04 MB per file.
 
-## Metadata
+## Metadata {#metadata}
 
 <Tabs queryString="metadata">
   <TabItem value="parameters" label="Parameter">
@@ -77,6 +77,6 @@ sremaxdv	1 	%	222 	Sonnenscheindauer; relativ zur absolut möglichen Tagessumme
   </TabItem>
 </Tabs>
 
-## Data usage
+## Data usage {#data-usage}
 
 See e.g. MeteoSwiss' [OBS network map](https://www.meteoswiss.admin.ch/services-and-publications/applications/measurement-values-and-measuring-networks.html#param=messnetz-beobachtungen&lang=en&table=false).

--- a/docs/a-data-groundbased/a9-phenological-observations.md
+++ b/docs/a-data-groundbased/a9-phenological-observations.md
@@ -7,13 +7,13 @@ The [Swiss Phenology Network](https://www.meteoswiss.admin.ch/weather/measuremen
 
 On the basis of this information, it is possible to investigate the impact of climate change on the vegetation. The observations also serve to generate forecasting models for the start of flowering.
 
-## Data download
+## Data download {#data-download}
 
 The Open Data from MeteoSwiss may be used without restriction; the **source must be cited** when reproducing or redistributing ("**Source: MeteoSwiss**").
 
 :white_check_mark: By using 'Open Data' from MeteoSchweiz, you confirm that you have taken note of the [Terms of use](/general/terms-of-use).
 
-### Download data automatically
+### Download data automatically {#download-data-automatically}
 
 Download **files per station** automatically via FSDI's REST API: [`https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-phenology`](https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-phenology)
 
@@ -21,11 +21,11 @@ Read our [information on how you can obtain data automatically](/general/downloa
 
 The STAC Browser can be a useful tool to facilitate the use of the API: [`https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.ogd-phenology`](https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.ogd-phenology)
 
-### Download data manually
+### Download data manually {#download-data-manually}
 
 Select and download **files per station** manually via MeteoSwiss' [Open Data Explorer](https://www.meteoswiss.admin.ch/services-and-publications/applications/ext/download-data-without-coding-skills.html#lang=en&mdt=normal&pgid=Phenology&sid=&col=&di=&tr=&hdr=).
 
-## Data structure
+## Data structure {#data-structure}
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -48,11 +48,11 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data format
+## Data format {#data-format}
 
 [`CSV`](https://opendatadocs.meteoswiss.ch/general/download#column-separators-and-decimal-dividers) with an estimated volume of ≤7.1 MB per file.
 
-## Metadata
+## Metadata {#metadata}
 
 <Tabs queryString="metadata">
   <TabItem value="parameters" label="Parameter">
@@ -97,7 +97,7 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data usage
+## Data usage {#data-usage}
 
 See e.g. MeteoSwiss' [PHENOLOGY network map](https://www.meteoswiss.admin.ch/services-and-publications/applications/measurement-values-and-measuring-networks.html#param=messnetz-phaenologie&lang=en&table=false).
 

--- a/docs/b-data-atmosphere/b1-radio-sounding.md
+++ b/docs/b-data-atmosphere/b1-radio-sounding.md
@@ -10,17 +10,17 @@ The radiosondes measure temperature and humidity as well as its position and alt
 
 The data obtained in this way are of great importance for weather forecasts and climate research. The data collected during the radiosonde's ascent are transmitted by radio to the receiving station in Payerne, where they are logged in the MeteoSwiss database. The results of the latest sounding are published  either as graphs ([emagrams](https://www.meteoswiss.admin.ch/services-and-publications/applications/radio-soundings.html#tab=radio-soundings-emagram)) or as [decoded data](https://www.meteoswiss.admin.ch/services-and-publications/applications/radio-soundings.html#tab=radio-soundings-decoded) files. 
 
-## Data download
+## Data download {#data-download}
 
 The file contains the data from the most recent sounding. The update frequency depends on the two soundings per day (at `00:00 UTC` and `12:00 UTC`).
 
 The following **example data file** is available for download: [`ogd-radiosounding_pay_now.csv`](https://github.com/MeteoSwiss/publication-opendata/tree/main/data-atmosphere/radiosounding)
 
-## Data format
+## Data format {#data-format}
 
 [`CSV`](https://opendatadocs.meteoswiss.ch/general/download#column-separators-and-decimal-dividers) with an estimated volume of 0.02 MB per file.
 
-## Metadata
+## Metadata {#metadata}
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -36,6 +36,6 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data usage
+## Data usage {#data-usage}
 
 See e.g. MeteoSwiss' [Emagrams](https://www.meteoswiss.admin.ch/services-and-publications/applications/radio-soundings.html#tab=radio-soundings-emagram).

--- a/docs/c-climate-data/c1-climate-stations_homogeneous.md
+++ b/docs/c-climate-data/c1-climate-stations_homogeneous.md
@@ -9,13 +9,13 @@ The measuring conditions under which meteorological data are collected may chang
 
 Homogeneous measurement series are available from the Swiss NBCN climate stations for the parameters temperature (average, minimum, maximum), precipitation, sunshine duration, vapour pressure, air pressure, global radiation, and wind speed. Data series for temperature, precipitation, and sunshine duration date back, in some cases, to the mid-nineteenth century.
 
-## Data download
+## Data download {#data-download}
 
 The Open Data from MeteoSwiss may be used without restriction; the **source must be cited** when reproducing or redistributing ("**Source: MeteoSwiss**").
 
 :white_check_mark: By using 'Open Data' from MeteoSchweiz, you confirm that you have taken note of the [Terms of use](/general/terms-of-use).
 
-### Download data automatically
+### Download data automatically {#download-data-automatically}
 
 Download **files per station** automatically via FSDI's REST API: [`https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-nbcn`](https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-nbcn)
 
@@ -23,11 +23,11 @@ Read our [information on how you can obtain data automatically](/general/downloa
 
 The STAC Browser can be a useful tool to facilitate the use of the API: [`https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.ogd-nbcn`](https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.ogd-nbcn)
 
-### Download data manually
+### Download data manually {#download-data-manually}
 
 Select and download **files per station** manually via MeteoSwiss' [Open Data Explorer](https://www.meteoswiss.admin.ch/services-and-publications/applications/ext/download-data-without-coding-skills.html#lang=en&mdt=homogenous&pgid=&sid=&col=&di=&tr=&hdr=).
 
-## Data structure
+## Data structure {#data-structure}
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -44,11 +44,11 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data format
+## Data format {#data-format}
 
 [`CSV`](https://opendatadocs.meteoswiss.ch/general/download#column-separators-and-decimal-dividers) with an estimated volume of ≤0.9 MB per file.
 
-## Metadata
+## Metadata {#metadata}
 
 <Tabs queryString="metadata">
   <TabItem value="parameters" label="Parameter">
@@ -66,7 +66,7 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data usage
+## Data usage {#data-usage}
 
 See e.g. MeteoSwiss' [Swiss NBCN network map](https://www.meteoswiss.admin.ch/services-and-publications/applications/measurement-values-and-measuring-networks.html#param=messnetz-klima&lang=en&table=false&compare=y).
 

--- a/docs/c-climate-data/c2-climate-percipitation-stations_homogeneous.md
+++ b/docs/c-climate-data/c2-climate-percipitation-stations_homogeneous.md
@@ -9,13 +9,13 @@ The measuring conditions under which meteorological data are collected may chang
 
 The data series of the Swiss NBCN precipitation stations were homogenised and date back, in some cases, to the mid-nineteenth century.
 
-## Data download
+## Data download {#data-download}
 
 The Open Data from MeteoSwiss may be used without restriction; the **source must be cited** when reproducing or redistributing ("**Source: MeteoSwiss**").
 
 :white_check_mark: By using 'Open Data' from MeteoSchweiz, you confirm that you have taken note of the [Terms of use](/general/terms-of-use).
 
-### Download data automatically
+### Download data automatically {#download-data-automatically}
 
 Download **files per station** automatically via FSDI's REST API: [`https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-nbcn-precip`](https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-nbcn-precip)
 
@@ -23,11 +23,11 @@ Read our [information on how you can obtain data automatically](/general/downloa
 
 The STAC Browser can be a useful tool to facilitate the use of the API: [`https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.ogd-nbcn-precip`](https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.ogd-nbcn-precip)
 
-### Download data manually
+### Download data manually {#download-data-manually}
 
 Select and download **files per station** manually via MeteoSwiss' [Open Data Explorer](https://www.meteoswiss.admin.ch/services-and-publications/applications/ext/download-data-without-coding-skills.html#lang=en&mdt=homogenous&pgid=Precipitation&sid=&col=&di=&tr=&hdr=).
 
-## Data structure
+## Data structure {#data-structure}
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -44,11 +44,11 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data format
+## Data format {#data-format}
 
 [`CSV`](https://opendatadocs.meteoswiss.ch/general/download#column-separators-and-decimal-dividers) with an estimated volume of *≤0.9 MB [to be verified]* per file.
 
-## Metadata
+## Metadata {#metadata}
 
 <Tabs queryString="metadata">
   <TabItem value="parameters" label="Parameter">
@@ -66,7 +66,7 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data usage
+## Data usage {#data-usage}
 
 See e.g. MeteoSwiss' [Swiss NBCN network map](https://www.meteoswiss.admin.ch/services-and-publications/applications/measurement-values-and-measuring-networks.html#param=messnetz-klima&lang=en&table=false&compare=y).
 

--- a/docs/c-climate-data/c3-ground-based-climate-data.md
+++ b/docs/c-climate-data/c3-ground-based-climate-data.md
@@ -19,7 +19,7 @@ These grid data products are statistically derived from ground-based measurement
 - [Daily Relative Sunshine Duration](https://www.meteoswiss.admin.ch/dam/jcr:981891db-30d1-47cc-a2e1-50c270bdaf22/ProdDoc_SrelD.pdf)
 - [Monthly and Yearly Relative Sunshine Duration](https://www.meteoswiss.admin.ch/dam/jcr:94421f3c-47f3-46fa-9939-1d494a0ce5fe/ProdDoc_SrelM.pdf)
 
-## Data download
+## Data download {#data-download}
 
 The following **example data files** are available for download:
 
@@ -49,14 +49,14 @@ The following **example data files** are available for download:
 
 <!-- @ENDNOSPELL@ -->
 
-## Data format
+## Data format {#data-format}
 
 The data format is [`NetCDF`](https://www.unidata.ucar.edu/software/netcdf/) with an estimated volume of 1.1 MB for *individual files [to be verified]*, and 13 MB for monthly files with daily data.
 
-## Coordinate system
+## Coordinate system {#coordinate-system}
 
 The coordinate system is [`Swiss LV95`](https://www.swisstopo.admin.ch/en/the-swiss-coordinates-system) / [`EPSG:2056`](https://epsg.io/2056). 
 
-## Data usage
+## Data usage {#data-usage}
 
 Follows.

--- a/docs/c-climate-data/c4-satellite-based-climate-data.md
+++ b/docs/c-climate-data/c4-satellite-based-climate-data.md
@@ -18,7 +18,7 @@ These grid data products are derived from [MeteoSat satellite data](https://www.
 **Cloud Cover**
 - *Hourly [to be verified]*, [Daily, Monthly and Yearly satellite-based Cloud Fractional Cover](https://www.meteoswiss.admin.ch/dam/jcr:af0c491c-4bfc-4efd-bcee-5d019004afd1/ProdDoc_CFC.pdf)
 
-## Data download
+## Data download {#data-download}
 
 The following **example data files** are available for download:
 
@@ -63,14 +63,14 @@ The following **example data files** are available for download:
 | ?                              |                      | Y                  | previous_year            | msg.SIS-No-Horizon.Y_ch02.lonlat      | LL84                   | EPSG:4326          |
 -->
 
-## Data format
+## Data format {#data-format}
 
 The data format is [`NetCDF`](https://www.unidata.ucar.edu/software/netcdf/) with an estimated volume of 0.1 MB per file.
 
-## Coordinate system
+## Coordinate system {#coordinate-system}
 
 The coordinate system is [`WGS84`](https://www.swisstopo.admin.ch/en/reference-system-as-basis-for-coordinates) / [`EPSG:4326`](https://epsg.io/4326). 
 
-## Data usage
+## Data usage {#data-usage}
 
 Follows.

--- a/docs/c-climate-data/c5-radar-based-climate-data.md
+++ b/docs/c-climate-data/c5-radar-based-climate-data.md
@@ -18,7 +18,7 @@ The following data are planned to be made available in 2025:
 - Monthly and Yearly radar-based Number of Hail Days with Hail >2cm *[Link to a detailed product documentation]*
 - Monthly and Yearly radar-based Number of Hail Days with Hail >4cm *[Link to a detailed product documentation]*
 
-## Data download
+## Data download {#data-download}
 
 The following data files are **in discussion to be processed**:
 
@@ -61,14 +61,14 @@ The following data files are **in discussion to be processed**:
 
 <!-- alle stdM, /Y weglassen -->
 
-## Data format
+## Data format {#data-format}
 
 The data format is [`NetCDF`](https://www.unidata.ucar.edu/software/netcdf/) <!-- with an estimated volume of ... MB per file --> .
 
-## Coordinate system
+## Coordinate system {#coordinate-system}
 
 The coordinate system is [`Swiss LV95`](https://www.swisstopo.admin.ch/en/the-swiss-coordinates-system) / [`EPSG:2056`](https://epsg.io/2056). 
 
-## Data usage
+## Data usage {#data-usage}
 
 Follows.

--- a/docs/c-climate-data/c6-climate-normals.md
+++ b/docs/c-climate-data/c6-climate-normals.md
@@ -16,11 +16,11 @@ For **grid data**, go to [Spatial climate normals](/c-climate-data/c7-spatial-cl
 
 :::
 
-## Data download
+## Data download {#data-download}
 
 You can download the available Open Data via [opendata.swiss](https://opendata.swiss/en/dataset/klimanormwerte/resource/e80497da-0ffb-4437-87bb-3d72e3296349), as ZIP (in `TXT` format).
 
-## Data structure
+## Data structure {#data-structure}
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -35,13 +35,13 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data format
+## Data format {#data-format}
 
 `TXT` with an estimated volume of ≤0.02 MB per file.
 
 The files are separated by tabs. 
 
-## Metadata
+## Metadata {#metadata}
 
 <Tabs queryString="metadata">
   <TabItem value="parameters" label="Parameter">
@@ -55,6 +55,6 @@ The files are separated by tabs.
   </TabItem>
 </Tabs>
 
-## Data usage
+## Data usage {#data-usage}
 
 See e.g. MeteoSwiss' [Normal values per measured parameter](https://www.meteoswiss.admin.ch/services-and-publications/applications/ext/climate-normtables.html#https%3A%2F%2Fservice.meteoswiss.ch%2Fproductbrowser%2FproductDisplay%2Fclimate-normtables%3Flang=en) application.

--- a/docs/c-climate-data/c7-spatial-climate-normals.md
+++ b/docs/c-climate-data/c7-spatial-climate-normals.md
@@ -23,7 +23,7 @@ MeteoSwiss provides monthly and annual maps for normal periods 1961-1990 and 199
 | previous_day | CH1995                 | EPSG:2056          | NETCDF           | SnormY9120 Normwert Monats-Sonnenscheindauer 1991-2020    |
 -->
 
-## Data download
+## Data download {#data-download}
 
 You can access the available Open Data via [opendata.swiss](https://opendata.swiss/en/dataset?q=klimanormwerte&sort=score%20desc%2C%20metadata_modified%20desc&organization=bundesamt-fur-meteorologie-und-klimatologie-meteoschweiz&res_format=SERVICE):
 
@@ -39,16 +39,16 @@ You can access the available Open Data via [opendata.swiss](https://opendata.swi
 - [over the norm period 1991-2020](https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.klimanormwerte-sonnenscheindauer_aktuelle_periode)
 - [over the norm period 1961-1990](https://data.geo.admin.ch/browser/index.html#/collections/ch.meteoschweiz.klimanormwerte-sonnenscheindauer_1961_1990)
 
-## Data format
+## Data format {#data-format}
 
 The data formats are 
 - [`NetCDF`](https://www.unidata.ucar.edu/software/netcdf/) with an estimated volume of 1.1 MB for *individual files [to be verified]*, and 13 MB for monthly files with daily data;
 - [`GeoTIFF`](https://trac.osgeo.org/geotiff).
 
-## Coordinate system
+## Coordinate system {#coordinate-system}
 
 The coordinate system is [`Swiss LV95`](https://www.swisstopo.admin.ch/en/the-swiss-coordinates-system) / [`EPSG:2056`](https://epsg.io/2056). 
 
-## Data usage
+## Data usage {#data-usage}
 
 See e.g. MeteoSwiss' [Norm value charts](https://www.meteoswiss.admin.ch/services-and-publications/applications/ext/climate-norm-maps-public.html#https%3A%2F%2Fservice.meteoswiss.ch%2Fproductbrowser%2FproductDisplay%2Fclimate-norm-maps-public%3Flang=en&cg1.parameter=FrostDays&cg1.normalPeriod=1961-1990&cg1.productName=climate-indicators-maps-norm) application.

--- a/docs/c-climate-data/c8-climate-scenarios.md
+++ b/docs/c-climate-data/c8-climate-scenarios.md
@@ -4,7 +4,7 @@ sidebar_position: 8
 
 # Climate scenarios
 
-## Data download
+## Data download {#data-download}
 
 You can access the `CH2018` data via the [`NCCS` website](https://www.nccs.admin.ch/nccs/en/home/climate-change-and-impacts/swiss-climate-change-scenarios.html).
 

--- a/docs/c-climate-data/c9-spatial-climate-scenarios.md
+++ b/docs/c-climate-data/c9-spatial-climate-scenarios.md
@@ -4,7 +4,7 @@ sidebar_position: 9
 
 # Spatial climate scenarios
 
-## Data download
+## Data download {#data-download}
 
 You can access the `CH2018` data via the [`NCCS` website](https://www.nccs.admin.ch/nccs/en/home/climate-change-and-impacts/swiss-climate-change-scenarios.html).
 

--- a/docs/e-forecast-data/e1-short-term-forecast-data.md
+++ b/docs/e-forecast-data/e1-short-term-forecast-data.md
@@ -33,7 +33,7 @@ The following parameters are currently under discussion to be made available:
 - Temperature 2 m (`TT`, 10 min values every 60 min)
 - Dew point temperature 2 m (`TD`, 10 min values every 60 min)
 
-## Data download
+## Data download {#data-download}
 
 The following **example data file**s are available for download:
 
@@ -48,15 +48,15 @@ The following **example data file**s are available for download:
 | **Temperature 2 m (`TT`)** | 10 min | 60 min | [TT_INCA_202106280700.nc](https://github.com/MeteoSwiss/publication-opendata-inca-data-nowcasting/blob/main/TT_INCA_202106280700.nc) | `ogd-nowcasting_TT_(date and time code).nc` | 13 |
 | **Dew point temperature 2 m (`TD`)** | 10 min | 60 min | [TD_INCA_202106280700.nc](https://github.com/MeteoSwiss/publication-opendata-inca-data-nowcasting/blob/main/TD_INCA_202106280700.nc) | `ogd-nowcasting_TD_(date and time code).nc` | 13 |
 
-## Data format
+## Data format {#data-format}
 
 The data format is [`NetCDF`](https://www.unidata.ucar.edu/software/netcdf).
 
-## Coordinate system
+## Coordinate system {#coordinate-system}
 
 The coordinate system is [`Swiss LV03`](https://www.swisstopo.admin.ch/en/national-triangulation-network-lv03) / [`EPSG 21781`](https://epsg.io/21781).
 
-## Metadata
+## Metadata {#metadata}
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -67,6 +67,6 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-## Data usage
+## Data usage {#data-usage}
 
 Examples of INCA data reading and visualisation can be found here: [jupyter notebooks](https://github.com/MeteoSwiss/inca-examples).

--- a/docs/e-forecast-data/e2-e3-numerical-weather-forecasting-model.mdx
+++ b/docs/e-forecast-data/e2-e3-numerical-weather-forecasting-model.mdx
@@ -40,16 +40,16 @@ The documentation covers the following topics:
 
 <br></br>
 
-## Getting started quickly
+## Getting started quickly {#getting-started-quickly}
 
-### Example notebooks: From retrieval to visualization
+### Example notebooks: From retrieval to visualization {#example-notebooks-from-retrieval-to-visualization}
 
 To get started quickly, explore the [Jupyter notebooks](https://github.com/MeteoSwiss/opendata-nwp-demos), which provide hands-on examples for retrieving, processing, and visualizing numerical weather prediction (NWP) model data from MeteoSwiss.
 
 
-## Available data
+## Available data {#available-data}
 
-### Models' specifications
+### Models' specifications {#models-specifications}
 
 | **Attributes**| **ICON-CH1-EPS** | **ICON-CH2-EPS**|
 |-----------|------------------|-----------------|
@@ -62,17 +62,17 @@ To get started quickly, explore the [Jupyter notebooks](https://github.com/Meteo
 | New Model Run (Initialization) | every 3 h | every 6 h |
 | Output Data Format | GRIB edition 2 | GRIB edition 2 |
 
-### Available parameters
+### Available parameters {#available-parameters}
 
 Each collection includes a downloadable CSV file with a continuously updated list of available parameters. The file includes metadata such as long name, standard unit, level type (single or multi level), vertical coordinate type, temporal horizon, aggregation type and start time. To access the parameter overview, open the collection page for the desired model - for example, [ICON-CH1-EPS](https://data.geo.admin.ch/browser/#/collections/ch.meteoschweiz.ogd-forecasting-icon-ch1?.language=en) or [ICON-CH2-EPS](https://data.geo.admin.ch/browser/#/collections/ch.meteoschweiz.ogd-forecasting-icon-ch2?.language=en). In the Assets section, download the file labeled Parameter Overview.
 
-### 24h window
+### 24h window {#24h-window}
 
 The data provided in the two collections described in the [Models' specifications table](#models-specifications) is accessible for **24 hours**.
 
 Data older than this is no longer available.
 
-## Download options
+## Download options {#download-options}
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -199,22 +199,22 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
-## Data Structure
+## Data Structure {#data-structure}
 
-### GRIB format
+### GRIB format {#grib-format}
 
 The data is provided in GRIB2 format, which is a binary format used internationally and defined by WMO.
 More information about the data format can be found in the [Manual on Codes](https://library.wmo.int/records/item/35769-manual-on-codes-volume-i-3-international-codes) published by WMO.
 
 > ⚠️ **WARNING**: Data located at the boundary of the spatial domain may be random.
 
-### GRIB file structure
+### GRIB file structure {#grib-file-structure}
 
  Each GRIB2 file contains data for a single model collection, one reference time, one forecast lead time, and one variable — either as the deterministic control run or the full ensemble. The following diagram shows a general overview.
 
 ![StructureDiagram](./static/docs_img/ogd_data_structure.drawio.png) <br></br>
 
-### Forecast data volume
+### Forecast data volume {#forecast-data-volume}
 
 The following tables summarize the expected volume of the different forecast files for **ICON-CH1-EPS** and **ICON-CH2-EPS**.
 
@@ -231,10 +231,10 @@ The following tables summarize the expected volume of the different forecast fil
 | Deterministic|  175.0 Bytes - 564.7 KiB| 4.9 MiB - 43.9 MiB|
 | Perturbed | 3.4 KiB - 11 MiB | 97.5 MiB - 877.5 MiB |
 
-### 3D model grid
+### 3D model grid {#3d-model-grid}
 The model data is structured on both a horizontal and vertical grid.
 
-#### Vertical grid
+#### Vertical grid {#vertical-grid}
 
 The vertical grid above the surface is a height-based coordinate system that describes terrain-following model levels. The closer the levels are to
 the surface, the narrower the layers they define, as shown in the image below. The model levels gradually change into levels of constant height as the distance from the surface increases.
@@ -269,7 +269,7 @@ Parameters are classified as either **single-level** or **multi-level**:
 
 For more detailed information on the vertical grid, read section 3.4 in [Working with the ICON Model](https://www.dwd.de/DE/leistungen/nwv_icon_tutorial/pdf_einzelbaende/icon_tutorial2024.pdf?__blob=publicationFile&v=3).
 
-#### Horizontal grid
+#### Horizontal grid {#horizontal-grid}
 
 The horizontal grid of the ICON-CH1-EPS and ICON-CH2-EPS models is based on a native icosahedral grid used by the ICON model (illustration below).
 
@@ -282,19 +282,19 @@ Since the provided data is defined on the native grid, the horizontal grid point
 Therefore, the longitude and latitude information corresponds to the middle of each triangle. For more detailed information on
 the horizontal grid, read section 2.1 in [Working with the ICON Model](https://www.dwd.de/DE/leistungen/nwv_icon_tutorial/pdf_einzelbaende/icon_tutorial2024.pdf?__blob=publicationFile&v=3).
 
-## Working with the forecast data
+## Working with the forecast data {#working-with-the-forecast-data}
 
-### Exploring GRIB files in Python
+### Exploring GRIB files in Python {#exploring-grib-files-in-python}
 Several Jupyter Notebooks explain how to download and work with forecast files in [xarray.DataArray](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html) format.
 To explore them, check out the GitHub repository [opendata-nwp-demos](https://github.com/MeteoSwiss/opendata-nwp-demos).
 
-### Reading GRIB files using ecCodes
+### Reading GRIB files using ecCodes {#reading-grib-files-using-eccodes}
 
 To work with GRIB files, you need a tool to decode the GRIB records. Each GRIB record holds the data for one parameter
 at one time and at one level. More information about the data format can be found in the [Manual on Codes](https://library.wmo.int/records/item/35769-manual-on-codes-volume-i-3-international-codes) published by WMO.
 We recommend installing ecCodes from ECMWF to read the data. Follow the installation guide provided by ECMWF [here](https://confluence.ecmwf.int/display/ECC/ecCodes+installation).
 
-#### Setting the local definitions of the COSMO consortium
+#### Setting the local definitions of the COSMO consortium {#setting-the-local-definitions-of-the-cosmo-consortium}
 
 The GRIB format relies on tables and templates to encode the metadata. Those tables allow for example the mapping of a triplet of numbers encoding a parameter to a descriptive string (`shortName`). The international tables are provided in ecCodes. Additionally,
 local definitions can be defined by each center. ECMWF specific definitions are also shiped with ecCodes. Some of the provided ICON data also requires the local definitions of the COSMO consortium.
@@ -316,7 +316,7 @@ To check the details of your information, you can run
 codes_info
 ```
 
-#### Decoding GRIB files with ecCodes
+#### Decoding GRIB files with ecCodes {#decoding-grib-files-with-eccodes}
 
 This section provides a brief introduction to decoding GRIB files using command-line tools provided by **ecCodes**.
 There are also C, Fortran 90 and Python interfaces, please refer to the [ecCodes documentation](https://confluence.ecmwf.int/display/ECC).
@@ -349,7 +349,7 @@ grib_dump filename.grib
 grib_dump -w key1=value1,key2=value2 filename.grib
 ```
 
-## FAQ/Troubleshooting
+## FAQ/Troubleshooting {#faqtroubleshooting}
 
 <details>
 <summary> <b> "Why can't I find the latitude or longitude coordinates?" </b> </summary>

--- a/docs/general/download.md
+++ b/docs/general/download.md
@@ -4,12 +4,12 @@ sidebar_position: 2
 
 # Download data
 
-### Ground-based measurements
+### Ground-based measurements {#ground-based-measurements}
 MeteoSwiss primarily uses the [Federal Spatial Data Infrastructure FSDI](https://www.geo.admin.ch/en/federal-spatial-data-infrastructure-fsdi), which is operated by [swisstopo](https://www.swisstopo.admin.ch/en/coordination-geo-information-and-services-cogis).
 
 The documentation below relates to the data provided on the FSDI.
 
-### Numerical weather forecasting model data
+### Numerical weather forecasting model data {#numerical-weather-forecasting-model-data}
 'Numerical weather forecasting model ICON-CH1/2-EPS' data are made available for download by the [CSCS - Swiss National Supercomputing Centre](https://www.cscs.ch/services/contractual-partners).
 
 :::info
@@ -20,8 +20,8 @@ The **different download options** are documented [**here**](/e-forecast-data/e2
 
 ---
 
-## How to download files automatically
-<!-- DO NOT CHANGE THIS TITLE ! -->
+## How to download files automatically {#how-to-download-files-automatically}
+
 The [FSDI provides a REST API](https://www.geo.admin.ch/en/rest-interface-stac-api) which adheres to the OGC STAC API standard.
 
 Each dataset is in its own collection - calling the `/collections` endpoint will **show all collections available**: [`https://data.geo.admin.ch/collections`](https://data.geo.admin.ch/api/stac/v1/collections)
@@ -29,7 +29,7 @@ Each dataset is in its own collection - calling the `/collections` endpoint will
 Each collection has a description - calling the [`/getCollections`](https://data.geo.admin.ch/api/stac/static/spec/v1/api.html#operation/getCollections) endpoint, will **show all collection metadata of a particular collection**: e.g. get the details of the collection "Automatic weather stations": [`https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-smn`](https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-smn)
 
 
-### How to check for new data
+### How to check for new data {#how-to-check-for-new-data}
 When downloading data from the STAC API, you might want to make sure to always retrieve the most current data.
 
 By default, asset objects are cached for 2 hours (Exception: Collections with 10 minute values are cached for 10 seconds). <!-- But there might be objects, that are updated more frequently. -->
@@ -42,9 +42,9 @@ We highly recommend to use preconditioning via the `If-Match` or `If-None-Match`
 For more information check [swisstopo's STAC API documentation](https://data.geo.admin.ch/api/stac/static/spec/v1/apitransactional.html#tag/Data/operation/getAssetObject).
 
 
-### Examples
+### Examples {#examples}
 
-#### Ground-based measurements
+#### Ground-based measurements {#ground-based-measurements-1}
 This [Jupyter notebook](https://github.com/MeteoSwiss/opendata/blob/main/notebooks/MonthlyMeanGlobalRadiation_HAI.ipynb) shows a simplified workflow for downloading and processing ground-based measurements of station `Salen-Reutenen (HAI)` from the STAC API.
 - The code used in the notebook is for demo purposes only. Code quality is not on production-grade level.
 - The packages that are required in order to run the Jupyter notebook are specified in the [Pipfile](https://github.com/MeteoSwiss/opendata/blob/main/Pipfile). A simple `pipenv install` will install the dependencies in a virtual environment on your machine.
@@ -52,13 +52,13 @@ This [Jupyter notebook](https://github.com/MeteoSwiss/opendata/blob/main/noteboo
 <!-- #### Radar data -->
 <!-- See [Import Data into QGIS](...) to see how a downloaded *radar* file can be imported into QGIS. -->
 
-#### Numerical weather forecasting model data
+#### Numerical weather forecasting model data {#numerical-weather-forecasting-model-data-1}
 The MeteoSwiss [opendata-nwp-demos](https://github.com/MeteoSwiss/opendata-nwp-demos) repository contains a collection of Jupyter notebooks that demonstrate how to access, download, and visualise data from numerical weather prediction (NWP) ICON-CH1/2-EPS models.
 
 
-## How CSV files are structured
+## How CSV files are structured {#how-csv-files-are-structured}
 
-### Data granularity
+### Data granularity {#data-granularity}
 For all types of data MeteoSwiss uses standard granularities. Depending on the application not all granularities are available. 
 
 For [Ground-based measurements](/a-data-groundbased) the lowest granularity is usually called 'original data' (`Originalwert`). Higher granularities are called 'aggregations' or 'aggregated values'. The World Meteorological Organization (WMO) does issue guidelines on how national weather services have to aggregate values and MeteoSwiss does follow these guidelines.
@@ -80,7 +80,7 @@ This is the overview of the granularities for [Ground-based](/a-data-groundbased
 | `y` | Yearly value | Usually aggregated from daily values and mostly used in climatology or climate change scenarios. | [Climate change scenarios](https://www.meteoswiss.admin.ch/climate/climate-change/swiss-climate-change-scenarios.html)|
 
 
-### Update frequency
+### Update frequency {#update-frequency}
 For [Ground-based](/a-data-groundbased) and [Atmosphere measurements](/b-data-atmosphere) as well as for [Climate stations – Homogeneous data series](/c-climate-data/c1-climate-stations_homogeneous) and [Climate precipitation stations - Homogeneous data series](/c-climate-data/c2-climate-percipitation-stations_homogeneous) MeteoSwiss provides an optimised directory structure separating older historical data, which is not updated regularly, and more recent data, which is updated more often. For realtime data we provide a third "now" directory with a high update frequency.
 
 This is the overview:
@@ -93,7 +93,7 @@ This is the overview:
 | `no type` | For certain data types this concept does not apply | varies | varies (e.g. [Granularity](./download#data-granularity) `y`) |
 
 
-### Column separators and decimal dividers
+### Column separators and decimal dividers {#column-separators-and-decimal-dividers}
 Generally, columns are separated with a semicolon (`;`).
 
 If you are using Windows Excel in a language version other than German, change the separator to `;` when opening the file (respectively use the ‘Text Conversion Assistant’ in the ‘Data’ menu).
@@ -110,7 +110,7 @@ Why did we choose the semicolon as a separator?
 The decimal divider is a full stop (`.`).
 
 
-### Encoding
+### Encoding {#encoding}
 
 CSV files are encoded in [`Windows-1252`](https://en.wikipedia.org/wiki/Windows-1252) to ensure that they are decoded correctly in Excel.
 
@@ -122,9 +122,9 @@ CSV files are encoded in [`Windows-1252`](https://en.wikipedia.org/wiki/Windows-
 
 
 
-## How date/time, time intervals and missing values are represented
+## How date/time, time intervals and missing values are represented {#how-datetime-time-intervals-and-missing-values-are-represented}
 
-### Time stamps and time intervals
+### Time stamps and time intervals {#time-stamps-and-time-intervals}
 Date/Time is expressed as `dd.mm.yyyy HH:MM`.
 
 All reference time stamps at MeteoSwiss are in [UTC](https://www.utctime.net)! Depending on the granularity the time stamp does define different intervals:
@@ -139,16 +139,16 @@ All reference time stamps at MeteoSwiss are in [UTC](https://www.utctime.net)! D
 - for higher granularities (`d`, `m` and `y`) the time stamp defines the beginning of the interval!
 
 
-### Missing values
+### Missing values {#missing-values}
 Missing values (e.g. due to instrument failure) are empty fields. Empty columns are used when a parameter is not measured at all at a certain station.
 
-## How GRIB2 files are structured
+## How GRIB2 files are structured {#how-grib2-files-are-structured}
 
 Numerical weather forecasting model data provided by MeteoSwiss are distributed in the [GRIB2 format](https://opendatadocs.meteoswiss.ch/e-forecast-data/e2-e3-numerical-weather-forecasting-model#grib-format), a binary and highly efficient format standardised by the World Meteorological Organization (WMO) for the storage and exchange of meteorological gridded data.
 
 GRIB2 files are designed to store multi-dimensional atmospheric fields, such as temperature, wind, or pressure across various heights, times, and geographical coordinates.
 
-### Overview of GRIB2 file content
+### Overview of GRIB2 file content {#overview-of-grib2-file-content}
 
 Each GRIB2 file contains:
 - A header with metadata such as model name, run time, parameter, and spatial resolution.
@@ -158,18 +158,18 @@ These files are designed for efficient storage and transfer of high-resolution m
 
 For a detailed breakdown of what is included in a single GRIB2 file, see the [GRIB File Structure section](https://opendatadocs.meteoswiss.ch/e-forecast-data/e2-e3-numerical-weather-forecasting-model#grib-file-structure).
 
-### Reading GRIB2 files
+### Reading GRIB2 files {#reading-grib2-files}
 
 Because GRIB2 files are binary and not human-readable, they require specialised tools or libraries for access.
 
-#### With Python
+#### With Python {#with-python}
 
 GRIB2 files can be read and processed using Python libraries that support GRIB decoding and metadata extraction. These libraries integrate with common scientific Python tools for data analysis and visualisation.
 
 Example workflows and tools are available in the [Exploring GRIB files in Python](https://opendatadocs.meteoswiss.ch/e-forecast-data/e2-e3-numerical-weather-forecasting-model#exploring-grib-files-in-python).
 
 
-#### With command-line tools
+#### With command-line tools {#with-command-line-tools}
 
 The [ecCodes command-line tools](https://confluence.ecmwf.int/display/ECC/ecCodes+Home), such as `grib_ls` and `grib_dump`, allow inspection and extraction of metadata and values directly from the terminal.
 

--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -14,7 +14,7 @@ Below you'll find answers to the most frequently asked questions. We continuousl
 <!--  - Warum sind Radardaten nicht auch Atmosphärenmessungen? (lim)  -->
 
 
-## What type of data can I get?
+## What type of data can I get? {#what-type-of-data-can-i-get}
 So far, the following data is available:
 - [A - Ground-based measurements](/a-data-groundbased)
 - [C - Climate data: Homogeneous data series](/c-climate-data)
@@ -25,15 +25,15 @@ Additional types of data will be released in the following months. The expected 
 <!--  [B - Atmosphere measurements](/b-data-atmosphere)  -->
 <!--  [D - Radar data](/d-data-radar)  -->
 
-## How may I use data?
+## How may I use data? {#how-may-i-use-data}
 Read the [Rights of use of the data](/general/terms-of-use#2-rights-of-use-of-the-data).
 
 
-## Is there a usage limitation?
+## Is there a usage limitation? {#is-there-a-usage-limitation}
 MeteoSwiss' download service partner swisstopo reserves the right to block or adjust the bandwidth for individual users, if these strain geo.admin.ch to a disproportionately wide extent. Read the [General Terms of Use and Operating Conditions of the Federal Spatial Data Infrastructure FSDI, chapter 2. Data use](https://www.geo.admin.ch/en/general-terms-of-use-fsdi#2.-Data-use).
 
 
-## How often is data updated?
+## How often is data updated? {#how-often-is-data-updated}
 For 'Ground-based measurements' as well as for 'Climate stations – Homogeneous data series' and 'Climate precipitation stations - Homogeneous data series' the update frequencies specified [here](/general/download#update-frequency) apply. For numerical weather forecasting model data, update frequencies depend on the model. Details on model run times and data availability can be found in the [Model Specifications section](https://opendatadocs.meteoswiss.ch/e-forecast-data/e2-e3-numerical-weather-forecasting-model#models-specifications) of the forecast data documentation.
 
 
@@ -45,7 +45,7 @@ For other data types, please refer to their corresponding documentation.
 <!-- Files contain the same data as in the API and are updated hourly. -->
  
 <!--
-## What formats does data come in?
+## What formats does data come in? {#what-formats-does-data-come-in}
 ...
 
 MeteoSwiss’ open data is retrieved in JSON format (”JavaScript Object Notation”). JSON is a compact file format for the exchange of data. JSON is a text format which is platform- and language agnostic and which can be read by humans as well as machines. The JSON format can easily be converted to other file formats such as .csv or .xml.
@@ -59,10 +59,10 @@ Data retrieved through the API is only available in JSON format, but DMI's open 
 For QGIS there is a plugin called "DMI Open Data", that can be used to easily import data. Please see our guide. -->
 
 
-## What about the quality control of data?
+## What about the quality control of data? {#what-about-the-quality-control-of-data}
 <!-- Do not change this title! -->
 
-### Ground-based measurements
+### Ground-based measurements {#ground-based-measurements}
 [Ground-based Measurements](/a-data-groundbased) are initially raw, not quality assured measurements, which may be faulty due to the way they are collected. The use of these data shall be with regard to the fact that the measurements may be faulty. Errors are typically due to malfunction of instruments caused by wear and tear or exposure to weather and on rare occasions from vandalism. <!-- Wear and tear of the instruments are handled proactively by performing service checks at the stations on a regular basis and changing the instruments within the given time frame. -->
 
 In order to minimise the risk of incorrect measurements, MeteoSwiss checks the plausibility of the data during a rolling period of 5 days from the time of measurement using several automatic and manual control methods. The manually checked data, which is the highest quality check available, is normally published 5 days after the measurement.
@@ -77,7 +77,7 @@ In order to minimise the risk of incorrect measurements, MeteoSwiss checks the p
 [Here](https://www.meteoswiss.admin.ch/weather/measurement-systems/data-management/data-preparation.html) you can find out more about how MeteoSwiss prepares its data. Topics include aggregation and calculation, completeness check, plausibility check, and homogenisation.
 
 <!--  
-### Precipitation radar products 
+### Precipitation radar products {#precipitation-radar-products}
 [Precipitation radar products](/d-radar-data/d1-precipitation-radar-products) ('CombiPrecip') are based on 10min automatic surface measurements and radar data. 
 
 Since some 10min data can be late or missing or there can be any issues with the radar, they are reprocessed automatically 8 days later, including all available and checked 10min automatic measured precipitation values. The published data will be overwritten automatically every 8 days.
@@ -88,7 +88,7 @@ For the best quality data we therefore recommend to use only the reprocessed dat
 
 :::
 
-### Spatial climate data
+### Spatial climate data {#spatial-climate-data}
 The daily spatial climate data [`RprelimD`, `TabsD`, `TmaxD`, `TminD` and `SrelD`](/c-climate-data/c3-ground-based-climate-data) are calculated daily, based on the available daily data. 
 
 As noted in the [ground-based measurements](/general/faq#ground-based-measurements)' section above, the data is beeing checked only later on, therefore a later recalculation of the products is necessary. Also the checked manually measured daily precipitation values are included after the end of the month in `RprelimD`, resulting in the `RhiresD` product.
@@ -102,20 +102,20 @@ Therefore the `TabsD`, `TmaxD`, `TminD`, `SrelD` and `RhiresD` products are beei
 *If you have questions regarding data from third parties, please contact the authority responsible for the specific station or the data derived therefrom.* -->
 
 
-## What if data is missing?
+## What if data is missing? {#what-if-data-is-missing}
 The 'open data' downloaded from MeteoSwiss corresponds to the data available to MeteoSwiss. Sometimes you may experience that some values are missing. The root cause of this is typically a malfunctioning measurement instrument, which MeteoSwiss will repair as soon as possible.
 
 Please also note that [missing values](/general/download#missing-values) - regardless of the cause - are always represented as 'empty fields'. This applies to the vast majority of cases in which no measurements are taken at all.
 
 <!--
-## What coordinate system is used for the location of the stations?
+## What coordinate system is used for the location of the stations? {#what-coordinate-system-is-used-for-the-location-of-the-stations}
 *The coordinate system used for the location of the stations is WGS84.*
 -->
 <!-- ### Why is MeteoSwiss' 1x1km grid data not available as open data? -->
 <!-- *The 1x1 km grid is used as an intermediate basis to construct the spatial resolutions 10x10 km, 20x20 km, municipality data and country data. Under certain weather conditions the 1x1 km grid data can be quite imprecise, but by aggregating it to larger areas the uncertainty is reduced. Furthermore, 3rd party data, which MeteoSwiss doesn’t have permission to redistribute, can be deducted directly from the 1x1 km grid data.* -->
 
 <!--
-## What if I have questions about the data?
+## What if I have questions about the data? {#what-if-i-have-questions-about-the-data}
 ...
 -->
 <!-- If you have questions regarding data, please contact the authority responsible for the specific station or the data derived therefrom.

--- a/docs/general/index.mdx
+++ b/docs/general/index.mdx
@@ -21,28 +21,28 @@ Additional datasets will be released in the following months. The expected quart
 MeteoSwiss is also working to enable access to certain data through individual API queries. However, this option will not be available before 2026.
 
 
-## Terms of use
+## Terms of use {#terms-of-use}
 
 The 'Open Data' from MeteoSwiss may be used without restriction; **the source must be cited** when reproducing or redistributing ("**Source: MeteoSwiss**").
 
 :white_check_mark: By using 'Open Data' from MeteoSchweiz, you confirm that you have taken note of the [Terms of use](/general/terms-of-use).
 
 
-## Staying up to date
+## Staying up to date {#staying-up-to-date}
 
 [Here](/general/status#systems-their-availability-and-support-contacts) you'll find information about involved systems, their availability and support contacts. 
 
 We keep interested parties and users regularly informed about our plans and changes: [Release notes (Changelog)](/general/status#release-notes-changelog).
 
 
-## Frequently asked questions (FAQ)
+## Frequently asked questions (FAQ) {#frequently-asked-questions-faq}
 
 [Here](/general/faq) you'll find answers to the most frequently asked questions. 
 
 We continuously update these based on questions received. If you cannot find an answer to your question, [contact us](/general/contact).
 
 
-## Contact
+## Contact {#contact}
 
 If you have [questions about the data](/a-data-groundbased), or [how to use the download service](/general/download), please check the [frequently asked questions (FAQ)](general/faq) first. 
 

--- a/docs/general/status.md
+++ b/docs/general/status.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Staying up to date
 
-## Systems, their availability and support contacts
+## Systems, their availability and support contacts {#systems-their-availability-and-support-contacts}
 
 | System | operated by | Operational status | Contact point |
 |:-------|:------------|:-------------------|:--------------|
@@ -16,7 +16,7 @@ sidebar_position: 3
 | Numerical weather forecasting model processing | [CSCS - Swiss National Supercomputing Centre](https://www.cscs.ch/services/contractual-partners) | [CSCS Status Page Central Services](https://status.cscs.ch/) | MeteoSwiss [Open Data support](https://www.meteoswiss.admin.ch/about-us/contact/contact-form.html) |
 
 
-## Release notes (Changelog)
+## Release notes (Changelog) {#release-notes-changelog}
 
 Check the changelog at [opendatadocs.meteoswiss.ch/changelog](https://opendatadocs.meteoswiss.ch/changelog) or subscribe to the [RSS feed](https://opendatadocs.meteoswiss.ch/changelog/rss.xml) to stay up-to-date about upcoming and released **changes of our Open Data service**, such as:
 
@@ -29,7 +29,7 @@ Check the changelog at [opendatadocs.meteoswiss.ch/changelog](https://opendatado
 **data.geo.admin.ch STAC – API download service** will not be subject to big breaking changes, because it adheres to the OGC STAC API standard. Our partner swisstopo continuously develops and improves it, so minor changes and bug fixes might change the behaviour of the API. If you suspect your integration has broken due to changed behaviour, check [GeoAdmin API Release Notes](https://api3.geo.admin.ch/releasenotes/index.html) where swisstopo announces released changes that might affect your integration.
 
 
-## Questions about the service
+## Questions about the service {#questions-about-the-service}
 
 If you have questions about the download API, how to use the service, or the documentation, please read the sections [download data](/general/download) and [frequently asked questions (FAQ)](/general/faq).
 

--- a/docs/general/terms-of-use.md
+++ b/docs/general/terms-of-use.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Terms of use
 
-## 1. Publication of meteorological and climatological data
+## 1. Publication of meteorological and climatological data {#1-publication-of-meteorological-and-climatological-data}
 The Federal Office of Meteorology and Climatology MeteoSwiss publishes the data it procures or generates to fulfil its legal tasks ([art. 10 para. 1 EMOTA](https://www.fedlex.admin.ch/eli/cc/2023/682/de#art_10)).
 
 The data are published free of charge, in a timely manner, in machine-readable form and in an open format on the Internet as 'Open Data' ([art. 10 para. 4 EMOTA](https://www.fedlex.admin.ch/eli/cc/2023/682/de#art_10)).
@@ -13,7 +13,7 @@ MeteoSwiss uses the [Federal Spatial Data Infrastructure (FSDI)](https://www.geo
 
 
 
-## 2. Rights of use of the data
+## 2. Rights of use of the data {#2-rights-of-use-of-the-data}
 The ‘Open Data’ of MeteoSwiss may be reused without restriction ([art. 10 para. 4 EMOTA](https://www.fedlex.admin.ch/eli/cc/2023/682/de#art_10)).
 
 In summary, you may:
@@ -32,7 +32,7 @@ The 'Open Data' of MeteoSwiss are published accordingly under the [Creative Comm
 
 
 
-## 3. Disclaimer of guarantee and liability
+## 3. Disclaimer of guarantee and liability {#3-disclaimer-of-guarantee-and-liability}
 
 MeteoSwiss provides no guarantee for the correctness of content, accuracy, up-to-dateness, reliability or completeness of the published 'Open Data' (see [art. 10 para. 6 EMOTA](https://www.fedlex.admin.ch/eli/cc/2023/682/de#art_10)). Any warranty and liability on the part of MeteoSwiss is excluded to the extent permitted by law.
 
@@ -40,7 +40,7 @@ MeteoSwiss provides essential services within the scope of its legal tasks (in p
 
 
 
-## 4. Use of the infrastructure
+## 4. Use of the infrastructure {#4-use-of-the-infrastructure}
 Please note that the infrastructure used by MeteoSwiss to provide 'Open Data' may only be used to the extent necessary to access the data. Any misuse (in particular use that is intended to damage the infrastructure or block its availability) or excessive use in terms of access frequency or data volume (in particular the high-frequency downloading of the same content) is prohibited and may result in your access being restricted or blocked ([art. 5 para. 1 let. d and para. 2 MetO](https://www.fedlex.admin.ch/eli/cc/2024/452/de#art_5)).
 
 In addition, the [General Terms of Use and Operating Conditions of the Federal Spatial Data Infrastructure FSDI](https://www.geo.admin.ch/en/general-terms-of-use-fsdi)  apply. Particular attention should be paid to chapter [2 Data use](https://www.geo.admin.ch/en/general-terms-of-use-fsdi#2.-Data-use) and chapter [5 General operating conditions](https://www.geo.admin.ch/en/general-terms-of-use-fsdi#5-General-operating-conditions).

--- a/i18n/de/docusaurus-plugin-content-docs/current/general/download.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/general/download.md
@@ -27,8 +27,7 @@ The **different download options** are documented [**here**](/e-forecast-data/e2
 
 ---
 
-## How to download files automatically  
-<!-- DO NOT CHANGE THIS TITLE ! -->
+## How to download files automatically {#how-to-download-files-automatically}
 
 The [FSDI provides a REST API](https://www.geo.admin.ch/en/rest-interface-stac-api) which adheres to the OGC STAC API standard.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/general/download.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/general/download.md
@@ -28,7 +28,8 @@ The **different download options** are documented [**here**](/e-forecast-data/e2
 
 ---
 
-## How to download files automatically  <!-- DO NOT CHANGE THIS TITLE ! -->
+## How to download files automatically {#how-to-download-files-automatically}
+
 The [FSDI provides a REST API](https://www.geo.admin.ch/en/rest-interface-stac-api) which adheres to the OGC STAC API standard.
 
 Each dataset is in its own collection - calling the `/collections` endpoint will **show all collections available**: [`https://data.geo.admin.ch/collections`](https://data.geo.admin.ch/api/stac/v1/collections)

--- a/i18n/it/docusaurus-plugin-content-docs/current/general/download.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/general/download.md
@@ -28,7 +28,8 @@ The **different download options** are documented [**here**](/e-forecast-data/e2
 
 ---
 
-## How to download files automatically  <!-- DO NOT CHANGE THIS TITLE ! -->
+## How to download files automatically {#how-to-download-files-automatically}
+
 The [FSDI provides a REST API](https://www.geo.admin.ch/en/rest-interface-stac-api) which adheres to the OGC STAC API standard.
 
 Each dataset is in its own collection - calling the `/collections` endpoint will **show all collections available**: [`https://data.geo.admin.ch/collections`](https://data.geo.admin.ch/api/stac/v1/collections)


### PR DESCRIPTION
Docusaurus allow to define the anchor link id (called "heading id") explicitly: https://docusaurus.io/docs/markdown-features/toc#heading-ids

Usually this ID is generated automatically based on the title. This can lead to situations, where a changed title leads to a broken anchor. To have more control over the links, I'd recommend to define explicit heading id at least for those parts, that are linked in the documentation.