### PR TITLE
Info on climate analyses adjusted

### DIFF
--- a/docs/a-data-groundbased/a2-automatic-precipitation-stations.md
+++ b/docs/a-data-groundbased/a2-automatic-precipitation-stations.md
@@ -73,6 +73,6 @@ See e.g. MeteoSwiss' [SwissMetNet network map](https://www.meteoswiss.admin.ch/s
 
 :::info
 
-For **climate analyses**, use the corresponding [Climate stations - Homogeneous measurements](https://opendatadocs.meteoswiss.ch/c-climate-data) instead.
+For **climate analyses (long-term evolution and change)**, use the [Climate stations - Homogeneous measurements](https://opendatadocs.meteoswiss.ch/c-climate-data) instead.
 
 :::


### PR DESCRIPTION
Für die Nutzer ist evtl nicht klar, was mit climate analyses genau gemeint ist. Deshalb habe ich in Klammern das noch klarer geschrieben - es geht um Analyse von Langzeitveränderungen, dort braucht es homogene Reihen. Zudem habe ich "corresponding" entfernt. Es könnte sein, dass es genau die gewünschte Station zB nicht gibt, trotzdem soll man homogene Messreihen für Klimaanalysen verwenden.