### PR TITLE
nwp-fix-broken-link

### DIFF
--- a/docs/e-forecast-data/e2-e3-numerical-weather-forecasting-model.mdx
+++ b/docs/e-forecast-data/e2-e3-numerical-weather-forecasting-model.mdx
@@ -18,7 +18,6 @@ MeteoSwiss uses two models, [**ICON-CH1-EPS** and **ICON-CH2-EPS**](https://www.
 <br></br>
 
 The documentation covers the following topics:
-- [News](#news)
 - [Getting started quickly](#getting-started-quickly)
     - [Example notebooks: From retrieval to visualization](#example-notebooks-from-retrieval-to-visualization)
 - [Available data](#available-data)
@@ -43,17 +42,6 @@ The documentation covers the following topics:
 - [Upcoming changes and changelog](#changes)
 
 <br></br>
-
-## News
-
-:::info
-
-New data available by 21 May. Stay tuned so you don't miss it.
-
-:::
-
-We are pleased to announce that pollen and analysis (KENDA-CH1) data will become available by 21 May. This release introduces pollen data for the ICON-CH2-EPS control run and makes analysis data available for existing parameters, including the newly added pollen parameters.
-
 
 ## Getting started quickly {#getting-started-quickly}
 
@@ -169,7 +157,7 @@ currently available, please consult the [parameter overview](#parameter-overview
 The same pollen variables are also available in the [KENDA-CH1 analysis dataset](https://opendatadocs.meteoswiss.ch/e-forecast-data/e5-numerical-weather-analysis-data). 
 The KENDA-CH1 runs, initialized hourly, represent the best estimate of the pollen state at a past point in time.
 
-For a practical example, see the [Jupyter notebook](https://github.com/MeteoSwiss/opendata-nwp-demos/10_icon_ch2_pollen_forecast.ipynb), 
+For a practical example, see the [Jupyter notebook](https://github.com/MeteoSwiss/opendata-nwp-demos/blob/main/10_icon_ch2_pollen_forecast.ipynb), 
 which demonstrates how to retrieve, convert and visualize pollen data.
 
 ## Download options {#download-options}
@@ -208,7 +196,7 @@ import TabItem from '@theme/TabItem';
     ```
 
     Each parameter in the request body serves the following purpose:
-    - `collections`: Defines the forecast model to retrieve (`ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS and `ch.meteoschweiz.ogd-forecasting-icon-ch2` for ICON-CH2-EPS).
+    - `collections`: Defines the forecast model to retrieve (`ch.meteoschweiz.ogd-forecasting-icon-ch1` for ICON-CH1-EPS, `ch.meteoschweiz.ogd-forecasting-icon-ch2` for ICON-CH2-EPS and `ch.meteoschweiz.ogd-analysis-kenda-ch1`).
     - `forecast:reference_datetime`: Specifies the desired forecast initialization time (e.g., `2025-03-12T12:00:00Z`).
     - `forecast:variable`: Indicates the meteorological parameter of interest (`TOT_PREC` for total precipitation, for example).
     - `forecast:perturbed`: Boolean flag determining if the request is for deterministic (`false`) or ensemble (`true`) data.


### PR DESCRIPTION
This PR:
- removes the news section
- fixes the link to the jupyter pollen notebook
- adds kenda-ch1 collection to the download section